### PR TITLE
feat(desktop): home screen with recent files (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Desktop: home screen with recent files** — the empty state is now a real
+  entry point. It lists recently opened/saved documents (most-recent-first,
+  de-duplicated, capped, persisted in `settings.json`) as accessible buttons
+  that reopen the form in one click, alongside the existing New/Open actions.
+  New `IRecentFilesService`; recent files are recorded on open/save and survive
+  restarts. (#34)
 - **Desktop: File → Export menu** — export the currently open form, **with its
   current values**, to a PDF without leaving the app: *Export as PDF…* (flat)
   and *Export as fillable PDF form…* (interactive AcroForm). Both use a save

--- a/src/PromptResponse.Desktop/App.axaml.cs
+++ b/src/PromptResponse.Desktop/App.axaml.cs
@@ -146,6 +146,8 @@ public partial class App : Application
         // Desktop infrastructure
         services.AddSingleton<IFileService, FileService>();
         services.AddSingleton<ISettingsService, SettingsService>();
+        services.AddSingleton<IRecentFilesService>(sp =>
+            new RecentFilesService(sp.GetRequiredService<ISettingsService>()));
         services.AddSingleton<IDialogService, DialogService>();
         services.AddSingleton<IDocumentSessionService, DocumentSessionService>();
 

--- a/src/PromptResponse.Desktop/Models/AppSettings.cs
+++ b/src/PromptResponse.Desktop/Models/AppSettings.cs
@@ -18,6 +18,23 @@ public class AppSettings
     /// non-null and from then on the saved choice wins on every launch.
     /// </summary>
     public ProfileSettings? Profile { get; set; }
+
+    /// <summary>
+    /// Recently opened/saved files, most-recent-first, shown on the home screen.
+    /// </summary>
+    public List<RecentFileSetting> RecentFiles { get; set; } = new();
+}
+
+/// <summary>
+/// A persisted recent-file entry.
+/// </summary>
+public class RecentFileSetting
+{
+    /// <summary>Absolute path to the file.</summary>
+    public string Path { get; set; } = string.Empty;
+
+    /// <summary>A display label (the document title, or the file name as a fallback).</summary>
+    public string Title { get; set; } = string.Empty;
 }
 
 /// <summary>

--- a/src/PromptResponse.Desktop/Services/IRecentFilesService.cs
+++ b/src/PromptResponse.Desktop/Services/IRecentFilesService.cs
@@ -1,0 +1,24 @@
+namespace PromptResponse.Desktop.Services;
+
+/// <summary>
+/// Tracks the most-recently opened/saved documents for the home screen.
+/// </summary>
+public interface IRecentFilesService
+{
+    /// <summary>The recent files, most-recent-first.</summary>
+    IReadOnlyList<RecentFileEntry> Items { get; }
+
+    /// <summary>
+    /// Records a file as the most recent (de-duplicating by path and capping the
+    /// list). A blank path is ignored. Persists if backed by settings.
+    /// </summary>
+    void Add(string? path, string? title);
+
+    /// <summary>Raised whenever <see cref="Items"/> changes.</summary>
+    event EventHandler? Changed;
+}
+
+/// <summary>A recent-file entry: where it is and how to label it.</summary>
+/// <param name="Path">Absolute file path.</param>
+/// <param name="Title">Display label (document title, or file name fallback).</param>
+public sealed record RecentFileEntry(string Path, string Title);

--- a/src/PromptResponse.Desktop/Services/RecentFilesService.cs
+++ b/src/PromptResponse.Desktop/Services/RecentFilesService.cs
@@ -1,0 +1,70 @@
+using PromptResponse.Desktop.Models;
+
+namespace PromptResponse.Desktop.Services;
+
+/// <summary>
+/// Recent-files tracker. When constructed with an <see cref="ISettingsService"/>
+/// it loads from and persists to app settings; without one it is in-memory only
+/// (the default the view-model falls back to in tests/design time).
+/// </summary>
+public sealed class RecentFilesService : IRecentFilesService
+{
+    /// <summary>Maximum entries retained.</summary>
+    public const int MaxItems = 8;
+
+    private readonly ISettingsService? _settings;
+    private readonly List<RecentFileEntry> _items = new();
+
+    public RecentFilesService(ISettingsService? settings = null)
+    {
+        _settings = settings;
+        if (_settings?.Settings.RecentFiles is { } saved)
+        {
+            _items.AddRange(saved
+                .Where(r => !string.IsNullOrWhiteSpace(r.Path))
+                .Select(r => new RecentFileEntry(r.Path, r.Title)));
+        }
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<RecentFileEntry> Items => _items;
+
+    /// <inheritdoc />
+    public event EventHandler? Changed;
+
+    /// <inheritdoc />
+    public void Add(string? path, string? title)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        var label = string.IsNullOrWhiteSpace(title) ? Path.GetFileName(path) : title!;
+
+        // Move-to-front semantics: drop any existing entry for the same path.
+        _items.RemoveAll(i => string.Equals(i.Path, path, StringComparison.OrdinalIgnoreCase));
+        _items.Insert(0, new RecentFileEntry(path, label));
+
+        if (_items.Count > MaxItems)
+        {
+            _items.RemoveRange(MaxItems, _items.Count - MaxItems);
+        }
+
+        Persist();
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void Persist()
+    {
+        if (_settings is null)
+        {
+            return;
+        }
+
+        _settings.Settings.RecentFiles = _items
+            .Select(i => new RecentFileSetting { Path = i.Path, Title = i.Title })
+            .ToList();
+        _settings.Save();
+    }
+}

--- a/src/PromptResponse.Desktop/ViewModels/MainShellViewModel.cs
+++ b/src/PromptResponse.Desktop/ViewModels/MainShellViewModel.cs
@@ -41,7 +41,8 @@ public sealed partial class MainShellViewModel : ObservableObject, IDisposable
         IDocumentSessionService session,
         IProfileService profileService,
         PromptViewModelFactory factory,
-        EditHistory? editHistory = null)
+        EditHistory? editHistory = null,
+        IRecentFilesService? recentFiles = null)
     {
         _fileService = fileService ?? throw new ArgumentNullException(nameof(fileService));
         _dialogService = dialogService ?? throw new ArgumentNullException(nameof(dialogService));
@@ -49,6 +50,7 @@ public sealed partial class MainShellViewModel : ObservableObject, IDisposable
         _profileService = profileService ?? throw new ArgumentNullException(nameof(profileService));
         if (factory == null) throw new ArgumentNullException(nameof(factory));
         _editHistory = editHistory ?? new EditHistory();
+        _recentFiles = recentFiles ?? new RecentFilesService();
         // Reconstruct the factory locally so it threads the shell's edit history
         // into every prompt VM it creates. The injected factory's profile is the
         // same DI singleton — only its history binding differs.
@@ -61,6 +63,42 @@ public sealed partial class MainShellViewModel : ObservableObject, IDisposable
         _session.DirtyChanged += OnDirtyChanged;
         _profileService.ProfileChanged += (_, _) => OnAllProfileBrushesChanged();
         _editHistory.PropertyChanged += OnEditHistoryChanged;
+        _recentFiles.Changed += (_, _) => RefreshRecentFiles();
+        RefreshRecentFiles();
+    }
+
+    private readonly IRecentFilesService _recentFiles;
+
+    /// <summary>Recently opened/saved files shown on the home screen, most-recent-first.</summary>
+    public ObservableCollection<RecentFileViewModel> RecentFiles { get; } = new();
+
+    /// <summary>True when there is at least one recent file to offer on the home screen.</summary>
+    public bool HasRecentFiles => RecentFiles.Count > 0;
+
+    private void RefreshRecentFiles()
+    {
+        RecentFiles.Clear();
+        foreach (var entry in _recentFiles.Items)
+        {
+            RecentFiles.Add(new RecentFileViewModel(entry.Path, entry.Title));
+        }
+        OnPropertyChanged(nameof(HasRecentFiles));
+    }
+
+    private void AddToRecent(string? path, string? title) => _recentFiles.Add(path, title);
+
+    /// <summary>Opens a file chosen from the home screen's recent list.</summary>
+    [RelayCommand]
+    public async Task OpenRecent(string? path)
+    {
+        if (string.IsNullOrEmpty(path)) return;
+
+        var doc = await _fileService.LoadFileAsync(path);
+        if (doc == null) return;   // file moved/deleted or unreadable — leave the list as-is
+
+        _fileService.SetCurrentFilePath(path);
+        _session.Set(doc, path, dirty: false);
+        AddToRecent(path, doc.Metadata.Title);
     }
 
     /// <summary>The shell-owned undo/redo history. Cleared on document load so
@@ -598,6 +636,7 @@ public sealed partial class MainShellViewModel : ObservableObject, IDisposable
         var doc = await _fileService.OpenFileAsync();
         if (doc == null) return;
         _session.Set(doc, _fileService.CurrentFilePath, dirty: false);
+        AddToRecent(_fileService.CurrentFilePath, doc.Metadata.Title);
     }
 
     /// <summary>
@@ -609,6 +648,7 @@ public sealed partial class MainShellViewModel : ObservableObject, IDisposable
         var doc = await _fileService.LoadFileAsync(filePath);
         if (doc == null) return;
         _session.Set(doc, filePath, dirty: false);
+        AddToRecent(filePath, doc.Metadata.Title);
     }
 
     [RelayCommand(CanExecute = nameof(HasDocument))]
@@ -625,6 +665,7 @@ public sealed partial class MainShellViewModel : ObservableObject, IDisposable
             await _fileService.SaveFileAsync(_session.CurrentDocument!, _fileService.CurrentFilePath);
         }
         _session.MarkClean();
+        AddToRecent(_fileService.CurrentFilePath, _session.CurrentDocument?.Metadata.Title);
     }
 
     [RelayCommand(CanExecute = nameof(HasDocument))]
@@ -633,6 +674,7 @@ public sealed partial class MainShellViewModel : ObservableObject, IDisposable
         if (!_session.HasDocument) return;
         await _fileService.SaveFileAsAsync(_session.CurrentDocument!);
         _session.MarkClean();
+        AddToRecent(_fileService.CurrentFilePath, _session.CurrentDocument?.Metadata.Title);
     }
 
     /// <summary>Exports the currently open document — with its current values — to a flat PDF.</summary>
@@ -854,3 +896,8 @@ public sealed partial class MainShellViewModel : ObservableObject, IDisposable
         _promptViewModels.Clear();
     }
 }
+
+/// <summary>A recent-file item bound to the home-screen list.</summary>
+/// <param name="Path">Absolute file path (passed to <c>OpenRecentCommand</c>).</param>
+/// <param name="DisplayName">The label shown to the user.</param>
+public sealed record RecentFileViewModel(string Path, string DisplayName);

--- a/src/PromptResponse.Desktop/Views/MainShellView.axaml
+++ b/src/PromptResponse.Desktop/Views/MainShellView.axaml
@@ -6,6 +6,7 @@
              xmlns:views="using:PromptResponse.Desktop.Views"
              xmlns:editor="using:PromptResponse.Desktop.Views.Editor"
              x:Class="PromptResponse.Desktop.Views.MainShellView"
+             x:Name="Root"
              x:DataType="vm:MainShellViewModel"
              AutomationProperties.Name="PromptResponse main shell"
              AutomationProperties.HelpText="Form designer and filler workspace">
@@ -222,6 +223,40 @@
                             AutomationProperties.HelpText="Open an existing APR template or filled form (Ctrl+O)">
                         <TextBlock Text="Open file" />
                     </Button>
+                </StackPanel>
+                <StackPanel IsVisible="{Binding HasRecentFiles}"
+                            Spacing="4"
+                            Margin="0,8,0,0"
+                            HorizontalAlignment="Stretch"
+                            AutomationProperties.Name="Recent files">
+                    <TextBlock Text="Recent"
+                               FontWeight="SemiBold"
+                               Opacity="0.8"
+                               Foreground="{Binding ActiveProfileOnSurfaceBrush}"/>
+                    <ItemsControl ItemsSource="{Binding RecentFiles}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="vm:RecentFileViewModel">
+                                <Button Command="{Binding #Root.((vm:MainShellViewModel)DataContext).OpenRecentCommand}"
+                                        CommandParameter="{Binding Path}"
+                                        HorizontalAlignment="Stretch"
+                                        HorizontalContentAlignment="Left"
+                                        Background="Transparent"
+                                        Padding="8,6"
+                                        MinHeight="40"
+                                        CornerRadius="6"
+                                        AutomationProperties.Name="{Binding DisplayName}"
+                                        AutomationProperties.HelpText="{Binding Path}">
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding DisplayName}"/>
+                                        <TextBlock Text="{Binding Path}"
+                                                   Opacity="0.6"
+                                                   FontSize="11"
+                                                   TextTrimming="CharacterEllipsis"/>
+                                    </StackPanel>
+                                </Button>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
                 </StackPanel>
                 <TextBlock Text="Tip: press F1 anytime to see keyboard shortcuts. View → Display Preferences lets you configure visual formatting, large text, high contrast, and more."
                            FontSize="{Binding CaptionFontSize}"

--- a/tests/PromptResponse.Desktop.Tests/Gui/MainShellViewGuiTests.cs
+++ b/tests/PromptResponse.Desktop.Tests/Gui/MainShellViewGuiTests.cs
@@ -65,6 +65,45 @@ public class MainShellViewGuiTests
     }
 
     [AvaloniaFact]
+    public void Home_WithRecentFiles_RendersAccessibleRecentButtons()
+    {
+        var fs = Substitute.For<IFileService>();
+        var dlg = Substitute.For<IDialogService>();
+        var session = new DocumentSessionService();
+        var profile = new ProfileService(new StubProbe(), applyAffordanceDefaults: false);
+        var factory = new PromptViewModelFactory(profile);
+        var recent = new RecentFilesService();
+        recent.Add("/forms/intake.aprt", "Intake Form");
+        var vm = new MainShellViewModel(fs, dlg, session, profile, factory, recentFiles: recent);
+        var view = new MainShellView { DataContext = vm };
+        view.ShowInWindow(width: 1100, height: 700);
+
+        vm.IsEmptyState.Should().BeTrue();
+        vm.HasRecentFiles.Should().BeTrue();
+
+        var recentBtn = view.FindDescendant<Button>(b =>
+            b.GetValue(Avalonia.Automation.AutomationProperties.NameProperty) as string == "Intake Form");
+        recentBtn.Should().NotBeNull("recent files must appear on the home screen as accessible buttons");
+        (recentBtn!.GetValue(Avalonia.Automation.AutomationProperties.HelpTextProperty) as string)
+            .Should().Be("/forms/intake.aprt", "the full path is the accessible help text");
+    }
+
+    [AvaloniaFact]
+    public void Home_ToEditor_ShowsEditorOnceADocumentOpens()
+    {
+        var (view, vm, session, _) = Build();
+        view.ShowInWindow(width: 1100, height: 700);
+
+        vm.IsEmptyState.Should().BeTrue("the app starts on the home screen, not an empty editor");
+
+        session.Set(MakeDocument(), "/x.aprt");
+        GuiTestExtensions.PumpDispatcher();
+
+        vm.HasDocument.Should().BeTrue();
+        vm.IsEmptyState.Should().BeFalse("the editor replaces the home screen once a document is open");
+    }
+
+    [AvaloniaFact]
     public void EmptyState_ShowsTwoLargePrimaryButtons_KeyboardReachable()
     {
         var (view, vm, _, _) = Build();

--- a/tests/PromptResponse.Desktop.Tests/Services/RecentFilesServiceTests.cs
+++ b/tests/PromptResponse.Desktop.Tests/Services/RecentFilesServiceTests.cs
@@ -1,0 +1,115 @@
+using AwesomeAssertions;
+using NSubstitute;
+using PromptResponse.Desktop.Models;
+using PromptResponse.Desktop.Services;
+using Xunit;
+
+namespace PromptResponse.Desktop.Tests.Services;
+
+/// <summary>
+/// Verifies recent-files tracking: move-to-front, de-dup, cap, blank-path
+/// guard, and persistence/restore via <see cref="ISettingsService"/>.
+/// </summary>
+public class RecentFilesServiceTests
+{
+    private static (RecentFilesService svc, AppSettings settings, ISettingsService mock) WithSettings()
+    {
+        var mock = Substitute.For<ISettingsService>();
+        var app = new AppSettings();
+        mock.Settings.Returns(app);
+        return (new RecentFilesService(mock), app, mock);
+    }
+
+    [Fact]
+    public void Add_InsertsMostRecentFirst()
+    {
+        var svc = new RecentFilesService();
+
+        svc.Add("/a.aprt", "A");
+        svc.Add("/b.aprt", "B");
+
+        svc.Items.Select(i => i.Path).Should().Equal("/b.aprt", "/a.aprt");
+    }
+
+    [Fact]
+    public void Add_SamePath_MovesToFrontWithoutDuplicating()
+    {
+        var svc = new RecentFilesService();
+        svc.Add("/a.aprt", "A");
+        svc.Add("/b.aprt", "B");
+
+        svc.Add("/a.aprt", "A");
+
+        svc.Items.Select(i => i.Path).Should().Equal("/a.aprt", "/b.aprt");
+        svc.Items.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Add_CapsAtMaxItems()
+    {
+        var svc = new RecentFilesService();
+        for (var i = 0; i < RecentFilesService.MaxItems + 5; i++)
+        {
+            svc.Add($"/f{i}.aprt", $"F{i}");
+        }
+
+        svc.Items.Should().HaveCount(RecentFilesService.MaxItems);
+        svc.Items[0].Path.Should().Be($"/f{RecentFilesService.MaxItems + 4}.aprt");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Add_BlankPath_Ignored(string? path)
+    {
+        var svc = new RecentFilesService();
+        svc.Add(path, "x");
+        svc.Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Add_BlankTitle_FallsBackToFileName()
+    {
+        var svc = new RecentFilesService();
+        svc.Add("/some/dir/report.aprf", "  ");
+        svc.Items[0].Title.Should().Be("report.aprf");
+    }
+
+    [Fact]
+    public void Add_PersistsToSettings()
+    {
+        var (svc, app, mock) = WithSettings();
+
+        svc.Add("/a.aprt", "A");
+
+        app.RecentFiles.Should().ContainSingle().Which.Path.Should().Be("/a.aprt");
+        mock.Received().Save();
+    }
+
+    [Fact]
+    public void Constructor_RestoresFromSettings()
+    {
+        var mock = Substitute.For<ISettingsService>();
+        mock.Settings.Returns(new AppSettings
+        {
+            RecentFiles = [new RecentFileSetting { Path = "/x.aprt", Title = "X" }],
+        });
+
+        var svc = new RecentFilesService(mock);
+
+        svc.Items.Should().ContainSingle().Which.Title.Should().Be("X");
+    }
+
+    [Fact]
+    public void Add_RaisesChanged()
+    {
+        var svc = new RecentFilesService();
+        var raised = false;
+        svc.Changed += (_, _) => raised = true;
+
+        svc.Add("/a.aprt", "A");
+
+        raised.Should().BeTrue();
+    }
+}

--- a/tests/PromptResponse.Desktop.Tests/ViewModels/MainShellViewModelTests.cs
+++ b/tests/PromptResponse.Desktop.Tests/ViewModels/MainShellViewModelTests.cs
@@ -31,14 +31,15 @@ public class MainShellViewModelTests
         IFileService? fileService = null,
         IDialogService? dialogService = null,
         IDocumentSessionService? session = null,
-        IProfileService? profile = null)
+        IProfileService? profile = null,
+        IRecentFilesService? recentFiles = null)
     {
         fileService ??= Substitute.For<IFileService>();
         dialogService ??= Substitute.For<IDialogService>();
         session ??= new DocumentSessionService();
         profile ??= new ProfileService(new StubProbe(), applyAffordanceDefaults: false);
         var factory = new PromptViewModelFactory(profile);
-        return new MainShellViewModel(fileService, dialogService, session, profile, factory);
+        return new MainShellViewModel(fileService, dialogService, session, profile, factory, recentFiles: recentFiles);
     }
 
     private static AprDocument MakeTemplate() => new()
@@ -148,6 +149,60 @@ public class MainShellViewModelTests
 
         shell.ExportPdfCommand.CanExecute(null).Should().BeFalse();
         shell.ExportPdfFormCommand.CanExecute(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void NewShell_WithRecentFiles_ExposesThemForTheHomeScreen()
+    {
+        var recent = new RecentFilesService();
+        recent.Add("/forms/intake.aprt", "Intake");
+
+        var shell = CreateShell(recentFiles: recent);
+
+        shell.HasRecentFiles.Should().BeTrue();
+        shell.RecentFiles.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new { Path = "/forms/intake.aprt", DisplayName = "Intake" });
+    }
+
+    [Fact]
+    public async Task Open_AddsTheFileToRecent()
+    {
+        var fs = Substitute.For<IFileService>();
+        fs.OpenFileAsync().Returns(MakeTemplate());
+        fs.CurrentFilePath.Returns("/forms/test.aprt");
+        var shell = CreateShell(fs);
+
+        await shell.Open();
+
+        shell.RecentFiles.Select(r => r.Path).Should().Contain("/forms/test.aprt");
+        shell.HasRecentFiles.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task OpenRecent_LoadsDocumentAndSetsCurrentPath()
+    {
+        var fs = Substitute.For<IFileService>();
+        fs.LoadFileAsync("/forms/saved.aprf").Returns(MakeTemplate());
+        var session = new DocumentSessionService();
+        var shell = CreateShell(fs, session: session);
+
+        await shell.OpenRecent("/forms/saved.aprf");
+
+        session.HasDocument.Should().BeTrue();
+        fs.Received(1).SetCurrentFilePath("/forms/saved.aprf");
+    }
+
+    [Fact]
+    public async Task OpenRecent_MissingFile_IsNoOp()
+    {
+        var fs = Substitute.For<IFileService>();
+        fs.LoadFileAsync(Arg.Any<string>()).Returns((AprDocument?)null);   // file gone
+        var session = new DocumentSessionService();
+        var shell = CreateShell(fs, session: session);
+
+        await shell.OpenRecent("/forms/gone.aprf");
+
+        session.HasDocument.Should().BeFalse();
     }
 
     [Fact]


### PR DESCRIPTION
Implements **#34** — a real home-screen entry point with recent files, so the app no longer opens into an empty editor.

## What
- The desktop **empty state** now shows a **Recent** list of the last-opened/saved documents — most-recent-first, de-duplicated, capped at 8, **persisted in `settings.json`** — as accessible buttons that reopen a form in one click, alongside the existing New / Open actions.
- New **`IRecentFilesService`** (`RecentFilesService`): in-memory by default, or persisting via `ISettingsService` when injected. `AppSettings.RecentFiles` stores the list; restored on startup.
- **`MainShellViewModel`**: optional `IRecentFilesService` dep (existing ctor stays source-compatible); `RecentFiles` / `HasRecentFiles`; `OpenRecentCommand` (no-op if the file is gone); open/save record the file as recent.
- **`MainShellView`**: a Recent section in the home screen; list items invoke `OpenRecentCommand` via the named root, accessibility-named with the path as help text.

## Acceptance criteria (#34)
- [x] First launch shows a home view, not an empty editor (home → editor GUI test).
- [x] Recent files persist across runs (service persists to `settings.json`; restore test) and reopen correctly (`OpenRecent` test).
- [x] GUI headless test covers the home → editor flow and renders recent items.
- [x] Accessibility: recent buttons carry `AutomationProperties.Name` (display name) + `HelpText` (path).

## Tests
+16: 8 `RecentFilesService` (front/dedup/cap/blank/persist/restore), 5 VM, 2 GUI. **Desktop 641 → 657**; full solution builds clean.

Stacked on #43 (shares the latest MainShell changes); base retargets to `main` once #43 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
