### PR TITLE
feat(pdf): stamp document metadata onto exported PDFs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **PDF exports carry document metadata** — generated PDFs (flat and fillable)
+  now stamp the APR title / author / description onto the PDF Info dictionary
+  (Title / Author / Subject) via pdfe v2.5.0's metadata authoring, for
+  provenance and search. (Unicode text rendering through the high-level builder
+  is still pending upstream — tracked in pdfe#398.)
 - **Packaged, self-contained distribution** — `scripts/publish.sh` produces
   single-file, self-contained `promptresponse` (GUI) and `apr` (CLI) binaries
   that run with **no .NET runtime installed** (verified under a stripped

--- a/src/PromptResponse.Rendering.Pdf/FillablePdfDocumentRenderer.cs
+++ b/src/PromptResponse.Rendering.Pdf/FillablePdfDocumentRenderer.cs
@@ -70,6 +70,7 @@ public sealed class FillablePdfDocumentRenderer : IDocumentRenderer
         };
         var model = _builder.Build(document, formOptions);
         var pdf = PdfDocumentBuilder.Create();
+        PdfRenderHelpers.ApplyMetadata(pdf, document.Metadata);
 
         var title = string.IsNullOrWhiteSpace(model.Title) ? "(untitled)" : model.Title;
         pdf.Heading(title, level: 1);
@@ -104,7 +105,7 @@ public sealed class FillablePdfDocumentRenderer : IDocumentRenderer
 
             case TableBlock t:
                 // Read-only for now; per-cell fillable fields are a follow-up.
-                pdf.Table(BuildTableRows(t), headerRow: true);
+                pdf.Table(PdfRenderHelpers.BuildTableRows(t), headerRow: true);
                 break;
         }
     }
@@ -133,23 +134,5 @@ public sealed class FillablePdfDocumentRenderer : IDocumentRenderer
         {
             pdf.Paragraph(f.HelpText!, HelpStyle);
         }
-    }
-
-    private static List<IReadOnlyList<string>> BuildTableRows(TableBlock table)
-    {
-        var rows = new List<IReadOnlyList<string>>(table.Rows.Count + 1);
-
-        var header = new List<string>(table.ColumnHeaders.Count + 1) { string.Empty };
-        header.AddRange(table.ColumnHeaders);
-        rows.Add(header);
-
-        foreach (var row in table.Rows)
-        {
-            var cells = new List<string>(row.Cells.Count + 1) { row.Label };
-            cells.AddRange(row.Cells.Select(c => c.Value));
-            rows.Add(cells);
-        }
-
-        return rows;
     }
 }

--- a/src/PromptResponse.Rendering.Pdf/PdfDocumentRenderer.cs
+++ b/src/PromptResponse.Rendering.Pdf/PdfDocumentRenderer.cs
@@ -57,6 +57,7 @@ public sealed class PdfDocumentRenderer : IDocumentRenderer
 
         var model = _builder.Build(document, options);
         var pdf = PdfDocumentBuilder.Create();
+        PdfRenderHelpers.ApplyMetadata(pdf, document.Metadata);
 
         var title = string.IsNullOrWhiteSpace(model.Title) ? "(untitled)" : model.Title;
         pdf.Heading(title, level: 1);
@@ -95,31 +96,8 @@ public sealed class PdfDocumentRenderer : IDocumentRenderer
                 break;
 
             case TableBlock t:
-                pdf.Table(BuildTableRows(t), headerRow: true);
+                pdf.Table(PdfRenderHelpers.BuildTableRows(t), headerRow: true);
                 break;
         }
-    }
-
-    /// <summary>
-    /// Flattens a <see cref="TableBlock"/> into pdfe's row form: a header row
-    /// (empty cell for the row-label column, then the column headers) followed
-    /// by one row per <see cref="TableRowBlock"/> (label cell, then values).
-    /// </summary>
-    private static List<IReadOnlyList<string>> BuildTableRows(TableBlock table)
-    {
-        var rows = new List<IReadOnlyList<string>>(table.Rows.Count + 1);
-
-        var header = new List<string>(table.ColumnHeaders.Count + 1) { string.Empty };
-        header.AddRange(table.ColumnHeaders);
-        rows.Add(header);
-
-        foreach (var row in table.Rows)
-        {
-            var cells = new List<string>(row.Cells.Count + 1) { row.Label };
-            cells.AddRange(row.Cells.Select(c => c.Value));
-            rows.Add(cells);
-        }
-
-        return rows;
     }
 }

--- a/src/PromptResponse.Rendering.Pdf/PdfRenderHelpers.cs
+++ b/src/PromptResponse.Rendering.Pdf/PdfRenderHelpers.cs
@@ -1,0 +1,59 @@
+using Pdfe.Core.Authoring;
+using PromptResponse.Core.Models;
+using PromptResponse.Core.Rendering;
+
+namespace PromptResponse.Rendering.Pdf;
+
+/// <summary>
+/// Shared helpers for the PDF renderers (flat and fillable).
+/// </summary>
+internal static class PdfRenderHelpers
+{
+    /// <summary>
+    /// Stamps the document's metadata onto the PDF Info dictionary (Title /
+    /// Author / Subject) using pdfe v2.5.0's metadata authoring, for provenance
+    /// and searchability.
+    /// </summary>
+    public static void ApplyMetadata(PdfDocumentBuilder pdf, Metadata meta)
+    {
+        if (!string.IsNullOrWhiteSpace(meta.Title))
+        {
+            pdf.Title(meta.Title);
+        }
+
+        // Prefer the document author; fall back to who filled it in.
+        var author = !string.IsNullOrWhiteSpace(meta.Author) ? meta.Author : meta.FilledBy;
+        if (!string.IsNullOrWhiteSpace(author))
+        {
+            pdf.Author(author!);
+        }
+
+        if (!string.IsNullOrWhiteSpace(meta.Description))
+        {
+            pdf.Subject(meta.Description!);
+        }
+    }
+
+    /// <summary>
+    /// Flattens a <see cref="TableBlock"/> into pdfe's row form: a header row
+    /// (empty cell for the row-label column, then the column headers) followed
+    /// by one row per <see cref="TableRowBlock"/> (label cell, then values).
+    /// </summary>
+    public static List<IReadOnlyList<string>> BuildTableRows(TableBlock table)
+    {
+        var rows = new List<IReadOnlyList<string>>(table.Rows.Count + 1);
+
+        var header = new List<string>(table.ColumnHeaders.Count + 1) { string.Empty };
+        header.AddRange(table.ColumnHeaders);
+        rows.Add(header);
+
+        foreach (var row in table.Rows)
+        {
+            var cells = new List<string>(row.Cells.Count + 1) { row.Label };
+            cells.AddRange(row.Cells.Select(c => c.Value));
+            rows.Add(cells);
+        }
+
+        return rows;
+    }
+}

--- a/tests/PromptResponse.Rendering.Pdf.Tests/PdfDocumentRendererTests.cs
+++ b/tests/PromptResponse.Rendering.Pdf.Tests/PdfDocumentRendererTests.cs
@@ -154,6 +154,23 @@ public class PdfDocumentRendererTests
     }
 
     [Fact]
+    public void Render_StampsDocumentMetadata_OntoThePdf()
+    {
+        var doc = new AprDocument
+        {
+            Metadata = new Metadata { Title = "Intake Form", Author = "Ada Lovelace", Description = "Please complete" },
+            Sections = [new Section { Id = "s", Title = "S", Prompts = [new Prompt { Id = "p", Label = "Name" }] }],
+        };
+
+        var bytes = _renderer.RenderToBytes(doc);
+
+        using var reopened = PdfeDoc.Open(bytes);
+        reopened.Title.Should().Be("Intake Form");
+        reopened.Author.Should().Be("Ada Lovelace");
+        reopened.Subject.Should().Be("Please complete");
+    }
+
+    [Fact]
     public void Render_NullArgs_Throw()
     {
         var act = () => _renderer.RenderToBytes(null!);


### PR DESCRIPTION
Quick win on pdfe v2.5.0: both PDF renderers stamp the APR title/author/description onto the PDF **Info dict** (Title/Author/Subject). Adds a shared `PdfRenderHelpers` (metadata + de-duplicated `BuildTableRows`). Round-trip test; **18** PDF renderer tests pass. Unicode-through-builder filed upstream as pdfe#398.

🤖 Generated with [Claude Code](https://claude.com/claude-code)