### PR TITLE
feat: finish v0.3.0 MVP — starter templates, onboarding, docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Starter templates** — 6 bundled, accessibility-validated office forms
+  (time-off request, expense report, IT access request, contact intake, event
+  registration, incident report) shipped in a `Templates/` folder next to the
+  binary and surfaced as a **"Start from a template"** gallery on the home
+  screen; selecting one opens a fresh unsaved copy. New `ITemplateCatalogService`.
+  Each template is hard-asserted accessible in CI (title, section/prompt labels,
+  help text, unique ids/labels). (#36)
+- **First-run onboarding** — a getting-started hint on the home screen (shown
+  until the user has opened or saved something) pointing new users to the
+  starter templates and F1 shortcuts. (#35)
 - **PDF exports carry document metadata** — generated PDFs (flat and fillable)
   now stamp the APR title / author / description onto the PDF Info dictionary
   (Title / Author / Subject) via pdfe v2.5.0's metadata authoring, for

--- a/VISION.md
+++ b/VISION.md
@@ -30,14 +30,19 @@ Every user has a capability profile — a set of sensory, motor, cognitive capab
 6. **Open format.** JSON fully documented. No vendor lock-in.
 7. **Stable, unique IDs.** IDs unique within scope; don't change on reorder.
 
-## Current state (0.1 baseline)
-**All 6 phases through visual design + integration are complete.** Live app uses:
+## Current state (v0.2.0 shipped; v0.3.0 MVP in progress)
+**v0.2.0 (2026-05-03)** delivered the capability-profile rendering system, the
+APRT structural editor (undo/redo + drag-drop), wizard mode, Linux AT-SPI2
+screen-reader support, and the full .NET 10 / Avalonia 12 / xunit.v3 upgrade.
+**v0.3.0 (in progress)** adds the shippable-MVP layer — see `docs/MVP.md`. Live app uses:
 - Capability-profile rendering (9 profile classes + CompositeProfile + ProfileService + OS auto-detect + Display Preferences UI)
-- Polymorphic prompt views (14 typed VMs + DataTemplateSelector + 6 dedicated views with text fallback for the rest)
-- New MainShell composition (DocumentSessionService, FormProgressViewModel, SearchViewModel) — all CommunityToolkit.Mvvm
-- Native menu, three-column layout, screen-reader-friendly status bar live region, empty state, F1 shortcuts dialog
-- WCAG-gated contrast tests + keyboard navigation tests + 11+ GUI automation tests using Avalonia.Headless
-- ~700 tests passing across Core / Cli / Desktop / Accessibility, 0 failing
+- Polymorphic prompt views (typed VMs + DataTemplateSelector + dedicated views with text fallback for the rest)
+- MainShell composition (DocumentSessionService, FormProgressViewModel, SearchViewModel, RecentFilesService, TemplateCatalogService) — all CommunityToolkit.Mvvm
+- **Home screen** with recent files + a starter-template gallery; native menu, three-column layout, screen-reader live region, F1 shortcuts dialog
+- **PDF export** (flat + fillable AcroForm) via the `IDocumentRenderer` seam on the pdfe engine, from both the CLI (`apr export --format=pdf [--fillable]`) and the desktop File → Export menu; PDFs carry document metadata
+- **Packaging**: self-contained single-file builds + installers + file associations (`docs/PACKAGING.md`)
+- WCAG-gated contrast tests + keyboard navigation tests + GUI automation tests using Avalonia.Headless
+- ~1300 tests passing across Core / Cli / Desktop / Accessibility / Rendering.Pdf, 0 failing; CI on .NET 10
 - Zero S3, signature, certificate, or template-update code
 
 ## Decision compass

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -61,12 +61,14 @@ Cross-reference with ROADMAP.md for detailed descriptions.
 | Unsaved changes tracking | P1 | ✅ | Prompt before losing work |
 | Collapsible sections | P1 | ✅ | Expand/collapse in editor |
 | **Windows 11 UI redesign** | P0 | 🔄 | Modern Fluent design system |
-| Dashboard/home screen | P1 | ⏳ | Recent docs, quick actions |
+| Dashboard/home screen | P1 | ✅ | Home screen with recent files + starter-template gallery (#34, #36) |
 | Progress tracking | P1 | ⏳ | Visual % complete indicator |
 | Search & navigation | P1 | ⏳ | Find prompts, jump to section |
 | Validation panel | P2 | ⏳ | Dedicated error/warning panel |
 | Print preview | P2 | ⏳ | WYSIWYG print layout |
-| Recent files list | P2 | ⏳ | Quick access to recent docs |
+| Recent files list | P2 | ✅ | Recent files on the home screen, persisted (#34) |
+| PDF / fillable export (GUI) | P1 | ✅ | File → Export: flat PDF + fillable AcroForm (#31) |
+| Starter templates | P1 | ✅ | 6 bundled accessible templates, selectable on home (#36) |
 
 ---
 
@@ -75,7 +77,7 @@ Cross-reference with ROADMAP.md for detailed descriptions.
 | Feature | Priority | Status | Notes |
 |---------|----------|--------|-------|
 | CSV/JSON/TXT export | P1 | ✅ | Via CLI export command |
-| **PDF export** | **P1** | **🔄** | Flattened PDF via `export --format=pdf` (pdfe engine). MVP: Latin-text/base-14; Unicode + tagged/accessible + fillable-AcroForm deferred (see CHANGELOG #31) |
+| **PDF export** | **P1** | **✅** | Flat **and** fillable-AcroForm PDF via CLI (`export --format=pdf [--fillable]`) and the desktop File → Export menu (pdfe engine); carries document metadata. Unicode text rendering through the builder is the remaining gap (pdfe#398) (#31) |
 | Word export (.docx) | P2 | ⏳ | Export to Word format |
 | Excel export (.xlsx) | P2 | ⏳ | Export to spreadsheet |
 
@@ -220,4 +222,4 @@ Track new feature requests here before adding to main list:
 
 ---
 
-*Feature tracker version 1.0 - Updated 2024-11-20*
+*Feature tracker updated 2026-06-06 — reflects the v0.3.0 MVP work (PDF export, home screen, starter templates, packaging). See `docs/MVP.md` and `CHANGELOG.md`.*

--- a/docs/MVP.md
+++ b/docs/MVP.md
@@ -1,6 +1,14 @@
 # MVP Cut-Line — v0.3.0 "Shippable"
 
-**Status:** planning · **Created:** 2026-06-05 · **Baseline:** v0.2.0
+**Status:** ~complete · **Created:** 2026-06-05 · **Updated:** 2026-06-06 · **Baseline:** v0.2.0
+
+> **Progress (2026-06-06):** all blockers and core P1s shipped on `main` —
+> #1 PDF export (✅, flat **+** fillable AcroForm), #2 renderer seam (✅),
+> #3 packaging/installers (✅), #4 home screen + recent files (✅),
+> #5 onboarding (✅), #6 starter templates (✅), #7 doc reconciliation (✅).
+> Bonus: GUI File → Export menu, document metadata in PDFs, pdfe upgraded to
+> v2.5.0 (fillable fields are screen-reader-named). Remaining P2s (#8 progress
+> UI, #9 validation panel, #10 profiles refactor, #11 macOS build) are optional.
 
 This is the concrete issue list for the first release a non-author can install,
 use, and get a presentable artifact out of — without a dev toolchain. See

--- a/examples/contact-intake.aprt
+++ b/examples/contact-intake.aprt
@@ -1,0 +1,131 @@
+{
+  "version": "1.0",
+  "documentType": "template",
+  "metadata": {
+    "title": "New Contact Intake",
+    "description": "Collect information from new contacts or potential customers",
+    "created": "2026-06-06T00:00:00Z",
+    "modified": "2026-06-06T00:00:00Z",
+    "author": "PromptResponse Team",
+    "templateId": "contact-intake",
+    "templateVersion": "1.0"
+  },
+  "sections": [
+    {
+      "id": "section_basic_info",
+      "title": "Basic Information",
+      "description": "Personal and contact details",
+      "prompts": [
+        {
+          "id": "prompt_full_name",
+          "label": "Full Name",
+          "response": "",
+          "hints": {
+            "placeholder": "John Michael Smith",
+            "expectedDataType": "text",
+            "helpText": "Complete name of the contact"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_email",
+          "label": "Email Address",
+          "response": "",
+          "hints": {
+            "placeholder": "john.smith@example.com",
+            "expectedDataType": "email",
+            "helpText": "Primary email address"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_phone",
+          "label": "Phone Number",
+          "response": "",
+          "hints": {
+            "placeholder": "+1 (555) 123-4567",
+            "expectedDataType": "phone",
+            "helpText": "Best contact phone number"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_organization_info",
+      "title": "Organization Details",
+      "description": "Company or organization information",
+      "prompts": [
+        {
+          "id": "prompt_organization",
+          "label": "Organization",
+          "response": "",
+          "hints": {
+            "placeholder": "ABC Corporation",
+            "expectedDataType": "text",
+            "helpText": "Name of the contact's organization or company"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_address",
+          "label": "Address",
+          "response": "",
+          "hints": {
+            "placeholder": "123 Main Street\\nSuite 100\\nNew York, NY 10001",
+            "expectedDataType": "multiline",
+            "helpText": "Full business address including street, city, state, and ZIP"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_preferences",
+      "title": "Contact Preferences",
+      "description": "How you prefer to be contacted",
+      "prompts": [
+        {
+          "id": "prompt_preferred_method",
+          "label": "Preferred Contact Method",
+          "response": "",
+          "hints": {
+            "expectedDataType": "text",
+            "suggestedValues": ["Email", "Phone", "Mail"],
+            "helpText": "Choose your preferred way to be contacted"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_how_heard",
+          "label": "How Did You Hear About Us?",
+          "response": "",
+          "hints": {
+            "placeholder": "Google search, referral, advertisement, etc.",
+            "expectedDataType": "text",
+            "helpText": "What led you to contact us?"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_additional_info",
+      "title": "Additional Information",
+      "description": "Any other relevant details",
+      "prompts": [
+        {
+          "id": "prompt_notes",
+          "label": "Notes",
+          "response": "",
+          "hints": {
+            "placeholder": "Add any additional information or context",
+            "expectedDataType": "multiline",
+            "helpText": "Any notes about this contact or their inquiry"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    }
+  ]
+}

--- a/examples/event-registration.aprt
+++ b/examples/event-registration.aprt
@@ -1,0 +1,149 @@
+{
+  "version": "1.0",
+  "documentType": "template",
+  "metadata": {
+    "title": "Event Registration",
+    "description": "Register for an event with attendee information and preferences",
+    "created": "2026-06-06T00:00:00Z",
+    "modified": "2026-06-06T00:00:00Z",
+    "author": "PromptResponse Team",
+    "templateId": "event-registration",
+    "templateVersion": "1.0"
+  },
+  "sections": [
+    {
+      "id": "section_attendee_info",
+      "title": "Attendee Information",
+      "description": "Basic registration details",
+      "prompts": [
+        {
+          "id": "prompt_attendee_name",
+          "label": "Attendee Name",
+          "response": "",
+          "hints": {
+            "placeholder": "John Smith",
+            "expectedDataType": "text",
+            "helpText": "Full name of the event attendee"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_email",
+          "label": "Email Address",
+          "response": "",
+          "hints": {
+            "placeholder": "john.smith@example.com",
+            "expectedDataType": "email",
+            "helpText": "Event confirmation will be sent to this address"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_phone",
+          "label": "Phone Number",
+          "response": "",
+          "hints": {
+            "placeholder": "+1 (555) 123-4567",
+            "expectedDataType": "phone",
+            "helpText": "Contact number for event communication"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_organization_info",
+      "title": "Organization",
+      "description": "Attendee's organization details",
+      "prompts": [
+        {
+          "id": "prompt_organization",
+          "label": "Organization",
+          "response": "",
+          "hints": {
+            "placeholder": "ABC Corporation",
+            "expectedDataType": "text",
+            "helpText": "Name of your company or organization"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_ticket_info",
+      "title": "Ticket Information",
+      "description": "Ticket type and additional attendees",
+      "prompts": [
+        {
+          "id": "prompt_ticket_type",
+          "label": "Ticket Type",
+          "response": "",
+          "hints": {
+            "expectedDataType": "text",
+            "suggestedValues": ["General", "Student", "VIP"],
+            "helpText": "Select your ticket category"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_num_guests",
+          "label": "Number of Guests",
+          "response": "",
+          "hints": {
+            "placeholder": "1",
+            "expectedDataType": "number",
+            "helpText": "How many additional guests will you bring?"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_accommodations",
+      "title": "Special Accommodations",
+      "description": "Dietary and accessibility needs",
+      "prompts": [
+        {
+          "id": "prompt_dietary_restrictions",
+          "label": "Dietary Restrictions",
+          "response": "",
+          "hints": {
+            "placeholder": "Vegetarian, gluten-free, nut allergy, etc.",
+            "expectedDataType": "text",
+            "helpText": "Let us know any dietary restrictions or allergies"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_accessibility",
+          "label": "Accessibility Accommodations",
+          "response": "",
+          "hints": {
+            "placeholder": "Wheelchair access, sign language interpreter, etc.",
+            "expectedDataType": "multiline",
+            "helpText": "Describe any accessibility accommodations you require"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_agreement",
+      "title": "Agreement",
+      "description": "Terms and conditions acceptance",
+      "prompts": [
+        {
+          "id": "prompt_agree_to_terms",
+          "label": "I Agree to the Event Terms and Conditions",
+          "response": "",
+          "hints": {
+            "expectedDataType": "boolean",
+            "suggestedValues": ["I Agree", "I Do Not Agree"],
+            "helpText": "You must agree to the terms to complete registration"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    }
+  ]
+}

--- a/examples/expense-report.aprt
+++ b/examples/expense-report.aprt
@@ -1,0 +1,163 @@
+{
+  "version": "1.0",
+  "documentType": "template",
+  "metadata": {
+    "title": "Expense Report",
+    "description": "Document and request reimbursement for business expenses",
+    "created": "2026-06-06T00:00:00Z",
+    "modified": "2026-06-06T00:00:00Z",
+    "author": "PromptResponse Team",
+    "templateId": "expense-report",
+    "templateVersion": "1.0"
+  },
+  "sections": [
+    {
+      "id": "section_report_header",
+      "title": "Report Header",
+      "description": "General information about the expense report",
+      "prompts": [
+        {
+          "id": "prompt_employee_name",
+          "label": "Employee Name",
+          "response": "",
+          "hints": {
+            "placeholder": "John Smith",
+            "expectedDataType": "text",
+            "helpText": "Full name of the employee submitting expenses"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_department",
+          "label": "Department",
+          "response": "",
+          "hints": {
+            "placeholder": "Sales",
+            "expectedDataType": "text",
+            "suggestedValues": [
+              "Sales",
+              "Marketing",
+              "Engineering",
+              "Human Resources",
+              "Finance",
+              "Operations"
+            ],
+            "helpText": "Department responsible for these expenses"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_report_period",
+          "label": "Report Period",
+          "response": "",
+          "hints": {
+            "placeholder": "June 1-30, 2026",
+            "expectedDataType": "text",
+            "helpText": "The time period covered by this expense report"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_expenses",
+      "title": "Expense Details",
+      "description": "One expense line. Duplicate this form (or add rows) for additional expenses.",
+      "prompts": [
+        {
+          "id": "prompt_exp1_date",
+          "label": "Date",
+          "response": "",
+          "hints": {
+            "placeholder": "2026-06-10",
+            "expectedDataType": "date",
+            "helpText": "Date of the expense"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_exp1_category",
+          "label": "Category",
+          "response": "",
+          "hints": {
+            "expectedDataType": "text",
+            "suggestedValues": [
+              "Travel",
+              "Meals",
+              "Lodging",
+              "Supplies",
+              "Other"
+            ],
+            "helpText": "Type of business expense"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_exp1_description",
+          "label": "Description",
+          "response": "",
+          "hints": {
+            "placeholder": "Conference attendee lunch",
+            "expectedDataType": "text",
+            "helpText": "Brief description of what was purchased"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_exp1_amount",
+          "label": "Amount",
+          "response": "",
+          "hints": {
+            "placeholder": "45.50",
+            "expectedDataType": "currency",
+            "helpText": "Cost of the expense in dollars"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_exp1_reimbursable",
+          "label": "Reimbursable",
+          "response": "",
+          "hints": {
+            "expectedDataType": "boolean",
+            "suggestedValues": [
+              "Yes",
+              "No"
+            ],
+            "helpText": "Is this expense eligible for reimbursement?"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_summary",
+      "title": "Summary",
+      "description": "Total amount and additional notes",
+      "prompts": [
+        {
+          "id": "prompt_total_amount",
+          "label": "Total Amount",
+          "response": "",
+          "hints": {
+            "placeholder": "165.50",
+            "expectedDataType": "currency",
+            "helpText": "Sum of all reimbursable expenses"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_notes",
+          "label": "Additional Notes",
+          "response": "",
+          "hints": {
+            "placeholder": "Add any additional context or clarifications",
+            "expectedDataType": "multiline",
+            "helpText": "Optional comments about expenses or attached receipts"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    }
+  ]
+}

--- a/examples/incident-report.aprt
+++ b/examples/incident-report.aprt
@@ -1,0 +1,181 @@
+{
+  "version": "1.0",
+  "documentType": "template",
+  "metadata": {
+    "title": "Incident Report",
+    "description": "Document workplace incidents for safety and compliance purposes",
+    "created": "2026-06-06T00:00:00Z",
+    "modified": "2026-06-06T00:00:00Z",
+    "author": "PromptResponse Team",
+    "templateId": "incident-report",
+    "templateVersion": "1.0"
+  },
+  "sections": [
+    {
+      "id": "section_reporter_info",
+      "title": "Reporter Information",
+      "description": "Details about the person reporting the incident",
+      "prompts": [
+        {
+          "id": "prompt_reporter_name",
+          "label": "Reporter Name",
+          "response": "",
+          "hints": {
+            "placeholder": "John Smith",
+            "expectedDataType": "text",
+            "helpText": "Full name of the person filing this report"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_reporter_role",
+          "label": "Reporter Role",
+          "response": "",
+          "hints": {
+            "placeholder": "Employee, Manager, Contractor, Visitor",
+            "expectedDataType": "text",
+            "helpText": "Position or relationship to the organization"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_incident_timing",
+      "title": "Incident Timing",
+      "description": "When the incident occurred",
+      "prompts": [
+        {
+          "id": "prompt_incident_date",
+          "label": "Date of Incident",
+          "response": "",
+          "hints": {
+            "placeholder": "2026-06-06",
+            "expectedDataType": "date",
+            "helpText": "The date when the incident occurred"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_incident_time",
+          "label": "Time of Incident",
+          "response": "",
+          "hints": {
+            "placeholder": "14:30",
+            "expectedDataType": "text",
+            "helpText": "Time of day when the incident occurred (approximate time acceptable)"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_incident_location",
+      "title": "Location",
+      "description": "Where the incident took place",
+      "prompts": [
+        {
+          "id": "prompt_location",
+          "label": "Location of Incident",
+          "response": "",
+          "hints": {
+            "placeholder": "Building A, Floor 3, Conference Room B",
+            "expectedDataType": "text",
+            "helpText": "Specific location or area where the incident occurred"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_incident_classification",
+      "title": "Incident Classification",
+      "description": "Type and nature of the incident",
+      "prompts": [
+        {
+          "id": "prompt_incident_type",
+          "label": "Incident Type",
+          "response": "",
+          "hints": {
+            "expectedDataType": "text",
+            "suggestedValues": ["Injury", "Property Damage", "Near Miss", "Security", "Other"],
+            "helpText": "Category of the incident"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_incident_description",
+      "title": "Incident Description",
+      "description": "Detailed account of what happened",
+      "prompts": [
+        {
+          "id": "prompt_description",
+          "label": "Description of What Happened",
+          "response": "",
+          "hints": {
+            "placeholder": "Provide a clear and detailed account of the incident",
+            "expectedDataType": "multiline",
+            "helpText": "Include sequence of events, conditions, and any contributing factors"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_people_involved",
+      "title": "People Involved",
+      "description": "Those affected by or witnessing the incident",
+      "prompts": [
+        {
+          "id": "prompt_people_involved",
+          "label": "People Involved",
+          "response": "",
+          "hints": {
+            "placeholder": "List names and roles of all people involved or witnessing the incident",
+            "expectedDataType": "multiline",
+            "helpText": "Include names, titles, and their relationship to the incident"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_immediate_action",
+      "title": "Immediate Actions",
+      "description": "Response taken at the time of incident",
+      "prompts": [
+        {
+          "id": "prompt_immediate_action",
+          "label": "Immediate Action Taken",
+          "response": "",
+          "hints": {
+            "placeholder": "First aid provided, area secured, emergency personnel called, etc.",
+            "expectedDataType": "multiline",
+            "helpText": "Describe steps taken immediately after the incident"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_followup",
+      "title": "Follow-up",
+      "description": "Investigation and corrective actions needed",
+      "prompts": [
+        {
+          "id": "prompt_followup_required",
+          "label": "Follow-up Investigation Required",
+          "response": "",
+          "hints": {
+            "expectedDataType": "boolean",
+            "suggestedValues": ["Yes", "No"],
+            "helpText": "Does this incident require further investigation?"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    }
+  ]
+}

--- a/examples/it-access-request.aprt
+++ b/examples/it-access-request.aprt
@@ -1,0 +1,149 @@
+{
+  "version": "1.0",
+  "documentType": "template",
+  "metadata": {
+    "title": "IT Access Request",
+    "description": "Request access to systems, applications, or resources for business purposes",
+    "created": "2026-06-06T00:00:00Z",
+    "modified": "2026-06-06T00:00:00Z",
+    "author": "PromptResponse Team",
+    "templateId": "it-access-request",
+    "templateVersion": "1.0"
+  },
+  "sections": [
+    {
+      "id": "section_requester_info",
+      "title": "Requester Information",
+      "description": "Details of the person requesting access",
+      "prompts": [
+        {
+          "id": "prompt_requester_name",
+          "label": "Requester Name",
+          "response": "",
+          "hints": {
+            "placeholder": "John Smith",
+            "expectedDataType": "text",
+            "helpText": "Full name of the employee requesting access"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_requester_email",
+          "label": "Requester Email",
+          "response": "",
+          "hints": {
+            "placeholder": "john.smith@company.com",
+            "expectedDataType": "email",
+            "helpText": "Work email address for contact"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_manager_info",
+      "title": "Manager Authorization",
+      "description": "Manager approval for the access request",
+      "prompts": [
+        {
+          "id": "prompt_manager_name",
+          "label": "Manager Name",
+          "response": "",
+          "hints": {
+            "placeholder": "Jane Doe",
+            "expectedDataType": "text",
+            "helpText": "Name of the employee's direct manager"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_access_request",
+      "title": "Access Request Details",
+      "description": "Specify what system access is needed",
+      "prompts": [
+        {
+          "id": "prompt_system_application",
+          "label": "System/Application Requested",
+          "response": "",
+          "hints": {
+            "placeholder": "Salesforce, GitHub, Jira, etc.",
+            "expectedDataType": "text",
+            "helpText": "Name of the system or application requiring access"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_access_level",
+          "label": "Access Level",
+          "response": "",
+          "hints": {
+            "expectedDataType": "text",
+            "suggestedValues": ["Read-only", "Standard", "Admin"],
+            "helpText": "Specify the level of permissions required"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_justification",
+          "label": "Business Justification",
+          "response": "",
+          "hints": {
+            "placeholder": "Explain why this access is needed for your job",
+            "expectedDataType": "multiline",
+            "helpText": "Describe the business need and how this access supports your role"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_duration",
+      "title": "Access Duration",
+      "description": "When the access should be active",
+      "prompts": [
+        {
+          "id": "prompt_start_date",
+          "label": "Start Date",
+          "response": "",
+          "hints": {
+            "placeholder": "2026-06-15",
+            "expectedDataType": "date",
+            "helpText": "When should access be granted?"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_end_date",
+          "label": "End Date (Optional)",
+          "response": "",
+          "hints": {
+            "placeholder": "2026-12-31",
+            "expectedDataType": "date",
+            "helpText": "When should access expire? Leave blank for permanent access."
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_approval",
+      "title": "Approval",
+      "description": "Manager approval of the access request",
+      "prompts": [
+        {
+          "id": "prompt_manager_approval",
+          "label": "Manager Approves This Request",
+          "response": "",
+          "hints": {
+            "expectedDataType": "boolean",
+            "suggestedValues": ["Approved", "Not Approved"],
+            "helpText": "Manager indicates approval or rejection"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    }
+  ]
+}

--- a/examples/time-off-request.aprt
+++ b/examples/time-off-request.aprt
@@ -1,0 +1,153 @@
+{
+  "version": "1.0",
+  "documentType": "template",
+  "metadata": {
+    "title": "Time-Off Request",
+    "description": "Request time off for vacation, sick leave, personal time, or other approved leave types",
+    "created": "2026-06-06T00:00:00Z",
+    "modified": "2026-06-06T00:00:00Z",
+    "author": "PromptResponse Team",
+    "templateId": "time-off-request",
+    "templateVersion": "1.0"
+  },
+  "sections": [
+    {
+      "id": "section_employee_info",
+      "title": "Employee Information",
+      "description": "Basic employee details",
+      "prompts": [
+        {
+          "id": "prompt_employee_name",
+          "label": "Employee Name",
+          "response": "",
+          "hints": {
+            "placeholder": "John Smith",
+            "expectedDataType": "text",
+            "helpText": "Full legal name of the requesting employee"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_employee_id",
+          "label": "Employee ID",
+          "response": "",
+          "hints": {
+            "placeholder": "EMP-2024-001",
+            "expectedDataType": "text",
+            "helpText": "Your unique employee identification number"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_request_date",
+          "label": "Request Date",
+          "response": "",
+          "hints": {
+            "placeholder": "2026-06-06",
+            "expectedDataType": "date",
+            "helpText": "The date this request is being submitted"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_leave_details",
+      "title": "Leave Details",
+      "description": "Specify the type and duration of requested time off",
+      "prompts": [
+        {
+          "id": "prompt_leave_type",
+          "label": "Leave Type",
+          "response": "",
+          "hints": {
+            "expectedDataType": "text",
+            "suggestedValues": ["Vacation", "Sick", "Personal", "Bereavement", "Jury Duty"],
+            "helpText": "Select the reason for your time-off request"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_start_date",
+          "label": "Start Date",
+          "response": "",
+          "hints": {
+            "placeholder": "2026-07-01",
+            "expectedDataType": "date",
+            "helpText": "The first day of your requested time off"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_end_date",
+          "label": "End Date",
+          "response": "",
+          "hints": {
+            "placeholder": "2026-07-10",
+            "expectedDataType": "date",
+            "helpText": "The last day of your requested time off"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_total_days",
+          "label": "Total Days",
+          "response": "",
+          "hints": {
+            "placeholder": "10",
+            "expectedDataType": "number",
+            "helpText": "Number of business days requested (calculated automatically if possible)"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_justification",
+      "title": "Reason",
+      "description": "Provide details about your leave request",
+      "prompts": [
+        {
+          "id": "prompt_reason",
+          "label": "Reason for Time Off",
+          "response": "",
+          "hints": {
+            "placeholder": "Describe the purpose of your requested time off",
+            "expectedDataType": "multiline",
+            "helpText": "Provide any relevant details or context for your request"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_manager_approval",
+      "title": "Manager Review",
+      "description": "Manager approval and signature",
+      "prompts": [
+        {
+          "id": "prompt_manager_name",
+          "label": "Manager Name",
+          "response": "",
+          "hints": {
+            "placeholder": "Jane Doe",
+            "expectedDataType": "text",
+            "helpText": "Name of the employee's direct manager"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "prompt_manager_approval",
+          "label": "Manager Approves This Request",
+          "response": "",
+          "hints": {
+            "expectedDataType": "boolean",
+            "suggestedValues": ["Approved", "Not Approved"],
+            "helpText": "Manager indicates approval or rejection of the request"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    }
+  ]
+}

--- a/src/PromptResponse.Desktop/App.axaml.cs
+++ b/src/PromptResponse.Desktop/App.axaml.cs
@@ -148,6 +148,8 @@ public partial class App : Application
         services.AddSingleton<ISettingsService, SettingsService>();
         services.AddSingleton<IRecentFilesService>(sp =>
             new RecentFilesService(sp.GetRequiredService<ISettingsService>()));
+        services.AddSingleton<ITemplateCatalogService>(sp =>
+            new TemplateCatalogService(sp.GetRequiredService<IAprSerializer>()));
         services.AddSingleton<IDialogService, DialogService>();
         services.AddSingleton<IDocumentSessionService, DocumentSessionService>();
 

--- a/src/PromptResponse.Desktop/PromptResponse.Desktop.csproj
+++ b/src/PromptResponse.Desktop/PromptResponse.Desktop.csproj
@@ -30,4 +30,17 @@
     <AvaloniaResource Include="Assets\*.ico" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Bundle the starter templates into a Templates/ folder next to the
+         binary so the home screen's "start from a template" gallery can load
+         them. Only the curated starters, not the larger demo files. -->
+    <_Starter Include="..\..\examples\time-off-request.aprt" />
+    <_Starter Include="..\..\examples\expense-report.aprt" />
+    <_Starter Include="..\..\examples\it-access-request.aprt" />
+    <_Starter Include="..\..\examples\contact-intake.aprt" />
+    <_Starter Include="..\..\examples\event-registration.aprt" />
+    <_Starter Include="..\..\examples\incident-report.aprt" />
+    <None Include="@(_Starter)" Link="Templates\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/src/PromptResponse.Desktop/Services/ITemplateCatalogService.cs
+++ b/src/PromptResponse.Desktop/Services/ITemplateCatalogService.cs
@@ -1,0 +1,17 @@
+namespace PromptResponse.Desktop.Services;
+
+/// <summary>
+/// Provides the starter templates bundled with the app, shown on the home
+/// screen as "start from a template" options.
+/// </summary>
+public interface ITemplateCatalogService
+{
+    /// <summary>The bundled starter templates, ordered by title.</summary>
+    IReadOnlyList<StarterTemplate> Templates { get; }
+}
+
+/// <summary>A bundled starter template.</summary>
+/// <param name="Title">The template's display title.</param>
+/// <param name="Path">Absolute path to the <c>.aprt</c> file.</param>
+/// <param name="Description">Optional one-line description.</param>
+public sealed record StarterTemplate(string Title, string Path, string? Description);

--- a/src/PromptResponse.Desktop/Services/TemplateCatalogService.cs
+++ b/src/PromptResponse.Desktop/Services/TemplateCatalogService.cs
@@ -1,0 +1,42 @@
+using PromptResponse.Core.Serialization;
+
+namespace PromptResponse.Desktop.Services;
+
+/// <summary>
+/// Loads the starter templates the build copies into a <c>Templates/</c> folder
+/// next to the binary. Reads each template's title from its metadata.
+/// </summary>
+public sealed class TemplateCatalogService : ITemplateCatalogService
+{
+    private readonly List<StarterTemplate> _templates = new();
+
+    public TemplateCatalogService(IAprSerializer serializer, string? templatesDirectory = null)
+    {
+        var dir = templatesDirectory ?? Path.Combine(AppContext.BaseDirectory, "Templates");
+        if (!Directory.Exists(dir))
+        {
+            return;
+        }
+
+        foreach (var file in Directory.EnumerateFiles(dir, "*.aprt"))
+        {
+            try
+            {
+                var doc = serializer.Deserialize(File.ReadAllText(file));
+                var title = string.IsNullOrWhiteSpace(doc.Metadata.Title)
+                    ? Path.GetFileNameWithoutExtension(file)
+                    : doc.Metadata.Title;
+                _templates.Add(new StarterTemplate(title, file, doc.Metadata.Description));
+            }
+            catch
+            {
+                // A malformed bundled template shouldn't crash the home screen; skip it.
+            }
+        }
+
+        _templates.Sort((a, b) => string.Compare(a.Title, b.Title, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<StarterTemplate> Templates => _templates;
+}

--- a/src/PromptResponse.Desktop/ViewModels/MainShellViewModel.cs
+++ b/src/PromptResponse.Desktop/ViewModels/MainShellViewModel.cs
@@ -42,7 +42,8 @@ public sealed partial class MainShellViewModel : ObservableObject, IDisposable
         IProfileService profileService,
         PromptViewModelFactory factory,
         EditHistory? editHistory = null,
-        IRecentFilesService? recentFiles = null)
+        IRecentFilesService? recentFiles = null,
+        ITemplateCatalogService? templateCatalog = null)
     {
         _fileService = fileService ?? throw new ArgumentNullException(nameof(fileService));
         _dialogService = dialogService ?? throw new ArgumentNullException(nameof(dialogService));
@@ -65,15 +66,46 @@ public sealed partial class MainShellViewModel : ObservableObject, IDisposable
         _editHistory.PropertyChanged += OnEditHistoryChanged;
         _recentFiles.Changed += (_, _) => RefreshRecentFiles();
         RefreshRecentFiles();
+
+        foreach (var t in (templateCatalog?.Templates ?? Array.Empty<StarterTemplate>()))
+        {
+            StarterTemplates.Add(new RecentFileViewModel(t.Path, t.Title));
+        }
     }
 
     private readonly IRecentFilesService _recentFiles;
+
+    /// <summary>Bundled starter templates shown on the home screen.</summary>
+    public ObservableCollection<RecentFileViewModel> StarterTemplates { get; } = new();
+
+    /// <summary>True when there is at least one starter template to offer.</summary>
+    public bool HasStarterTemplates => StarterTemplates.Count > 0;
+
+    /// <summary>Starts a new, unsaved document from a bundled starter template.</summary>
+    [RelayCommand]
+    public async Task NewFromTemplate(string? path)
+    {
+        if (string.IsNullOrEmpty(path)) return;
+
+        var doc = await _fileService.LoadFileAsync(path);
+        if (doc == null) return;
+
+        // A fresh copy — clear the source path so saving prompts "Save As".
+        _fileService.ClearCurrentFilePath();
+        _session.Set(doc, null, dirty: false);
+    }
 
     /// <summary>Recently opened/saved files shown on the home screen, most-recent-first.</summary>
     public ObservableCollection<RecentFileViewModel> RecentFiles { get; } = new();
 
     /// <summary>True when there is at least one recent file to offer on the home screen.</summary>
     public bool HasRecentFiles => RecentFiles.Count > 0;
+
+    /// <summary>
+    /// First-run onboarding hint: shown on the home screen until the user has
+    /// opened or saved something (i.e. while there are no recent files).
+    /// </summary>
+    public bool ShowGettingStarted => !HasRecentFiles;
 
     private void RefreshRecentFiles()
     {
@@ -83,6 +115,7 @@ public sealed partial class MainShellViewModel : ObservableObject, IDisposable
             RecentFiles.Add(new RecentFileViewModel(entry.Path, entry.Title));
         }
         OnPropertyChanged(nameof(HasRecentFiles));
+        OnPropertyChanged(nameof(ShowGettingStarted));
     }
 
     private void AddToRecent(string? path, string? title) => _recentFiles.Add(path, title);

--- a/src/PromptResponse.Desktop/Views/MainShellView.axaml
+++ b/src/PromptResponse.Desktop/Views/MainShellView.axaml
@@ -193,6 +193,20 @@
                            HorizontalAlignment="Center"
                            TextAlignment="Center"
                            Foreground="{Binding ActiveProfileMutedTextBrush}"/>
+                <Border IsVisible="{Binding ShowGettingStarted}"
+                        Background="{Binding ActiveProfileElevatedSurfaceBrush}"
+                        BorderBrush="{Binding ActiveProfileBorderBrush}"
+                        BorderThickness="1"
+                        CornerRadius="8"
+                        Padding="14,10"
+                        Margin="0,4,0,0"
+                        AutomationProperties.Name="Getting started">
+                    <TextBlock Text="New here? Pick a starter template below to see how a form is built, or create a blank template. Press F1 anytime for keyboard shortcuts."
+                               FontSize="{Binding CaptionFontSize}"
+                               TextWrapping="Wrap"
+                               TextAlignment="Center"
+                               Foreground="{Binding ActiveProfileOnSurfaceBrush}"/>
+                </Border>
                 <StackPanel Orientation="Horizontal"
                             Spacing="14"
                             HorizontalAlignment="Center"
@@ -253,6 +267,34 @@
                                                    FontSize="11"
                                                    TextTrimming="CharacterEllipsis"/>
                                     </StackPanel>
+                                </Button>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+                <StackPanel IsVisible="{Binding HasStarterTemplates}"
+                            Spacing="4"
+                            Margin="0,8,0,0"
+                            HorizontalAlignment="Stretch"
+                            AutomationProperties.Name="Start from a template">
+                    <TextBlock Text="Start from a template"
+                               FontWeight="SemiBold"
+                               Opacity="0.8"
+                               Foreground="{Binding ActiveProfileOnSurfaceBrush}"/>
+                    <ItemsControl ItemsSource="{Binding StarterTemplates}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="vm:RecentFileViewModel">
+                                <Button Command="{Binding #Root.((vm:MainShellViewModel)DataContext).NewFromTemplateCommand}"
+                                        CommandParameter="{Binding Path}"
+                                        HorizontalAlignment="Stretch"
+                                        HorizontalContentAlignment="Left"
+                                        Background="Transparent"
+                                        Padding="8,6"
+                                        MinHeight="40"
+                                        CornerRadius="6"
+                                        AutomationProperties.Name="{Binding DisplayName}"
+                                        AutomationProperties.HelpText="Create a new form from this template">
+                                    <TextBlock Text="{Binding DisplayName}"/>
                                 </Button>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>

--- a/tests/PromptResponse.AccessibilityTests/AprAccessibilityValidationTests.cs
+++ b/tests/PromptResponse.AccessibilityTests/AprAccessibilityValidationTests.cs
@@ -253,6 +253,51 @@ public class AprAccessibilityValidationTests
         }
     }
 
+    // ── Bundled starter templates (#36) — hard-asserted (no silent skip) ──
+
+    private static string RepoRoot => Path.Combine(
+        Directory.GetCurrentDirectory(), "..", "..", "..", "..", "..");
+
+    [Theory]
+    [InlineData("time-off-request.aprt")]
+    [InlineData("expense-report.aprt")]
+    [InlineData("it-access-request.aprt")]
+    [InlineData("contact-intake.aprt")]
+    [InlineData("event-registration.aprt")]
+    [InlineData("incident-report.aprt")]
+    public async Task StarterTemplate_IsAccessible(string fileName)
+    {
+        var path = Path.Combine(RepoRoot, "examples", fileName);
+        File.Exists(path).Should().BeTrue($"the bundled starter template {fileName} must exist");
+
+        var document = _serializer.Deserialize(await File.ReadAllTextAsync(path));
+
+        document.Metadata.Title.Should().NotBeNullOrWhiteSpace("a template needs a title");
+
+        var labels = new List<string>();
+        var ids = new List<string>();
+        void Walk(Section section, string context)
+        {
+            section.Id.Should().NotBeNullOrWhiteSpace($"every section needs an id ({context})");
+            section.Title.Should().NotBeNullOrWhiteSpace($"every section needs a title ({context})");
+            ids.Add(section.Id);
+            foreach (var p in section.Prompts)
+            {
+                p.Id.Should().NotBeNullOrWhiteSpace($"every prompt needs an id (in {section.Title})");
+                p.Label.Should().NotBeNullOrWhiteSpace($"every prompt needs a label (in {section.Title})");
+                p.Hints.HelpText.Should().NotBeNullOrWhiteSpace(
+                    $"starter-template prompt '{p.Label}' should have help text for screen readers");
+                labels.Add(p.Label);
+                ids.Add(p.Id);
+            }
+            foreach (var child in section.Sections) Walk(child, $"{context} / {section.Title}");
+        }
+        foreach (var s in document.Sections) Walk(s, fileName);
+
+        labels.Should().OnlyHaveUniqueItems("duplicate labels confuse screen readers");
+        ids.Should().OnlyHaveUniqueItems("ids must be unique within a document");
+    }
+
     [Theory]
     [InlineData("examples/simple-contact-form.aprt")]
     [InlineData("examples/employment-application.apr")]

--- a/tests/PromptResponse.Desktop.Tests/Services/TemplateCatalogServiceTests.cs
+++ b/tests/PromptResponse.Desktop.Tests/Services/TemplateCatalogServiceTests.cs
@@ -1,0 +1,73 @@
+using AwesomeAssertions;
+using PromptResponse.Core.Serialization;
+using PromptResponse.Desktop.Services;
+using Xunit;
+
+namespace PromptResponse.Desktop.Tests.Services;
+
+/// <summary>
+/// Verifies the starter-template catalog reads bundled <c>.aprt</c> files,
+/// titles them from metadata, and sorts them.
+/// </summary>
+public class TemplateCatalogServiceTests
+{
+    private readonly AprJsonSerializer _serializer = new();
+
+    private static string WriteTemplate(string dir, string fileName, string title)
+    {
+        var path = Path.Combine(dir, fileName);
+        File.WriteAllText(path,
+            $$"""
+            { "version": "1.0", "documentType": "template",
+              "metadata": { "title": "{{title}}", "description": "d" },
+              "sections": [ { "id": "s", "title": "S", "prompts": [] } ] }
+            """);
+        return path;
+    }
+
+    [Fact]
+    public void Templates_AreLoadedAndSortedByTitle()
+    {
+        var dir = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            WriteTemplate(dir, "b.aprt", "Zebra Form");
+            WriteTemplate(dir, "a.aprt", "Apple Form");
+
+            var catalog = new TemplateCatalogService(_serializer, dir);
+
+            catalog.Templates.Select(t => t.Title).Should().Equal("Apple Form", "Zebra Form");
+            catalog.Templates[0].Path.Should().EndWith("a.aprt");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void MissingDirectory_YieldsEmptyCatalog()
+    {
+        var catalog = new TemplateCatalogService(_serializer, Path.Combine(Path.GetTempPath(), "nope-" + Guid.NewGuid()));
+        catalog.Templates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MalformedTemplate_IsSkipped_NotCrashing()
+    {
+        var dir = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "bad.aprt"), "{ not json");
+            WriteTemplate(dir, "good.aprt", "Good Form");
+
+            var catalog = new TemplateCatalogService(_serializer, dir);
+
+            catalog.Templates.Should().ContainSingle().Which.Title.Should().Be("Good Form");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/tests/PromptResponse.Desktop.Tests/ViewModels/MainShellViewModelTests.cs
+++ b/tests/PromptResponse.Desktop.Tests/ViewModels/MainShellViewModelTests.cs
@@ -32,14 +32,16 @@ public class MainShellViewModelTests
         IDialogService? dialogService = null,
         IDocumentSessionService? session = null,
         IProfileService? profile = null,
-        IRecentFilesService? recentFiles = null)
+        IRecentFilesService? recentFiles = null,
+        ITemplateCatalogService? templateCatalog = null)
     {
         fileService ??= Substitute.For<IFileService>();
         dialogService ??= Substitute.For<IDialogService>();
         session ??= new DocumentSessionService();
         profile ??= new ProfileService(new StubProbe(), applyAffordanceDefaults: false);
         var factory = new PromptViewModelFactory(profile);
-        return new MainShellViewModel(fileService, dialogService, session, profile, factory, recentFiles: recentFiles);
+        return new MainShellViewModel(fileService, dialogService, session, profile, factory,
+            recentFiles: recentFiles, templateCatalog: templateCatalog);
     }
 
     private static AprDocument MakeTemplate() => new()
@@ -190,6 +192,34 @@ public class MainShellViewModelTests
 
         session.HasDocument.Should().BeTrue();
         fs.Received(1).SetCurrentFilePath("/forms/saved.aprf");
+    }
+
+    [Fact]
+    public void NewShell_WithStarterTemplates_ExposesThemForTheHomeScreen()
+    {
+        var catalog = Substitute.For<ITemplateCatalogService>();
+        catalog.Templates.Returns(new[] { new StarterTemplate("Time-Off Request", "/t/time-off.aprt", "d") });
+
+        var shell = CreateShell(templateCatalog: catalog);
+
+        shell.HasStarterTemplates.Should().BeTrue();
+        shell.StarterTemplates.Should().ContainSingle()
+            .Which.DisplayName.Should().Be("Time-Off Request");
+    }
+
+    [Fact]
+    public async Task NewFromTemplate_LoadsAFreshUnsavedDocument()
+    {
+        var fs = Substitute.For<IFileService>();
+        fs.LoadFileAsync("/t/time-off.aprt").Returns(MakeTemplate());
+        var session = new DocumentSessionService();
+        var shell = CreateShell(fs, session: session);
+
+        await shell.NewFromTemplate("/t/time-off.aprt");
+
+        session.HasDocument.Should().BeTrue();
+        // A fresh copy: the source path is cleared so the first save is "Save As".
+        fs.Received(1).ClearCurrentFilePath();
     }
 
     [Fact]


### PR DESCRIPTION
Completes the v0.3.0 MVP cut-line (docs/MVP.md).

## #36 Starter templates
6 bundled, **accessibility-validated** office forms (time-off request, expense report, IT access request, contact intake, event registration, incident report). The Desktop build copies them into a `Templates/` folder next to the binary; `ITemplateCatalogService` enumerates them; the home screen shows a **"Start from a template"** gallery and `NewFromTemplate` opens a fresh unsaved copy. Each template is **hard-asserted accessible in CI** (title, section/prompt labels, help text, unique ids/labels) — non-skipping, unlike the legacy theory.

## #35 First-run onboarding
A getting-started hint on the home screen (shown until the user has opened/saved anything) pointing new users to the starter templates + F1 shortcuts.

## #37 Doc reconciliation
`VISION.md` current-state rewritten (v0.2.0 shipped / v0.3.0 in progress); `docs/FEATURES.md` statuses updated (PDF export, home screen, recent files, starter templates → ✅) + dated; `docs/MVP.md` marked ~complete.

## Tests
+6 accessibility (templates), +3 catalog service, +2 VM. Full solution builds clean; **Accessibility 106**, **Desktop 662** passing.

This closes the MVP blockers + core P1s; remaining items (#8 progress UI, #9 validation panel, #10 profiles refactor, #11 macOS build) are optional P2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)