### PR TITLE
ci(release): macOS tarballs (Apple Silicon + Intel) (#41)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,3 +107,35 @@ jobs:
           files: |
             dist/*.zip
             dist/*-setup.exe
+
+  # ── macOS: self-contained tarballs (Apple Silicon + Intel) ───────────
+  # Single-file binaries; a notarized .app bundle is a follow-up (needs an
+  # Apple signing identity). Users gatekeeper-approve on first launch.
+  macos:
+    name: macOS (tarballs)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+      - name: Resolve version
+        id: ver
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            v="${{ github.event.inputs.version }}"
+          else
+            v="${GITHUB_REF#refs/tags/}"; v="${v#v}"
+          fi
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+      - name: Publish (self-contained, single-file)
+        run: |
+          bash scripts/publish.sh --rid osx-arm64 --version "${{ steps.ver.outputs.version }}"
+          bash scripts/publish.sh --rid osx-x64   --version "${{ steps.ver.outputs.version }}"
+      - name: Attach to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.ver.outputs.version }}
+          files: dist/*.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **macOS release builds** — the release workflow now produces self-contained
+  tarballs for Apple Silicon (`osx-arm64`) and Intel (`osx-x64`) on a macOS
+  runner, alongside the Linux tarball and Windows installer/zip. Unsigned (first
+  launch needs a Gatekeeper approval); a notarized `.app` is a follow-up. (#41)
 - **Per-section completion progress** — the right-rail Progress panel now lists
   each top-level section's answered/total (with a ✓ when complete) under the
   overall progress bar; each row is accessibility-named. `FormProgressViewModel`

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -12,7 +12,8 @@ scripts/publish.sh --version 0.3.0
 
 # Other targets
 scripts/publish.sh --rid win-x64   --version 0.3.0
-scripts/publish.sh --rid osx-x64   --version 0.3.0   # macOS (see issue #41)
+scripts/publish.sh --rid osx-arm64 --version 0.3.0   # macOS (Apple Silicon)
+scripts/publish.sh --rid osx-x64   --version 0.3.0   # macOS (Intel)
 ```
 
 Each run publishes both projects (self-contained, `PublishSingleFile`,
@@ -73,6 +74,9 @@ iscc /DMyAppVersion=0.3.0 /DPublishDir=publish\win-x64 /DRepoRoot=. packaging\wi
 
 ## Notes & follow-ups
 
-- **macOS** packaging (`.app` / notarization) is tracked as issue #41.
+- **macOS**: the release builds self-contained tarballs for Apple Silicon
+  (`osx-arm64`) and Intel (`osx-x64`) on a macOS runner (#41). They're unsigned,
+  so first launch needs a Gatekeeper approval; a notarized `.app` bundle (needs
+  an Apple signing identity) is a follow-up.
 - The portable zip on Windows requires no install but does not register file
   associations — use the installer for that.


### PR DESCRIPTION
Closes out the v0.3.0 milestone. Adds a `macos` job to `release.yml` (on `macos-latest`) running `publish.sh` for **osx-arm64** + **osx-x64**, attaching self-contained tarballs alongside Linux + Windows. Locally verified `--rid osx-arm64` produces a valid **Mach-O arm64** binary. Unsigned (Gatekeeper approval on first launch); notarized `.app` is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)