### PR TITLE
feat(core): safe CEL-subset expression engine (Milestone 2 foundation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Expression engine** (`PromptResponse.Core.Expressions`) — a safe, pure-data
+  evaluator for the spec's CEL subset (Appendix B/C): prompt ids are variables
+  holding response strings, with `_this`/`_today` built-ins, `ctx.*` context, the
+  `int`/`double`/`timestamp`/`size`/`matches`/`string` functions, and standard
+  operators. No code execution; bounded nesting + length and regex timeouts;
+  missing variables degrade to null. Foundation for Milestone 2 (computed fields,
+  conditional visibility, cross-field validation). 48 tests.
+
 - **macOS release builds** — the release workflow now produces self-contained
   tarballs for Apple Silicon (`osx-arm64`) and Intel (`osx-x64`) on a macOS
   runner, alongside the Linux tarball and Windows installer/zip. Unsigned (first

--- a/src/PromptResponse.Core/Expressions/CelValue.cs
+++ b/src/PromptResponse.Core/Expressions/CelValue.cs
@@ -1,0 +1,104 @@
+using System.Globalization;
+
+namespace PromptResponse.Core.Expressions;
+
+/// <summary>The dynamic type of a <see cref="CelValue"/>.</summary>
+public enum CelKind
+{
+    /// <summary>An unset / missing value (e.g. a referenced field that doesn't exist).</summary>
+    Null,
+    /// <summary>A string (the native type of every prompt response).</summary>
+    String,
+    /// <summary>A number (from a literal or <c>int()</c>/<c>double()</c>).</summary>
+    Number,
+    /// <summary>A boolean.</summary>
+    Bool,
+    /// <summary>A list of values (from a list literal or <c>exprSuggestValues</c>).</summary>
+    List,
+    /// <summary>A point in time, produced by <c>timestamp(...)</c>.</summary>
+    Timestamp,
+}
+
+/// <summary>
+/// A value in the expression language — the spec's CEL subset. Responses are
+/// strings; numbers come from <c>int()</c>/<c>double()</c>, timestamps from
+/// <c>timestamp()</c>. Immutable; no behavior beyond type-safe access.
+/// </summary>
+public readonly struct CelValue
+{
+    private readonly object? _value;
+
+    private CelValue(CelKind kind, object? value)
+    {
+        Kind = kind;
+        _value = value;
+    }
+
+    /// <summary>The dynamic kind of this value.</summary>
+    public CelKind Kind { get; }
+
+    /// <summary>The null/unset value.</summary>
+    public static CelValue Null { get; } = new(CelKind.Null, null);
+
+    /// <summary>Wraps a string value (null becomes empty).</summary>
+    public static CelValue Of(string value) => new(CelKind.String, value ?? string.Empty);
+
+    /// <summary>Wraps a numeric value.</summary>
+    public static CelValue Of(double value) => new(CelKind.Number, value);
+
+    /// <summary>Wraps a boolean value.</summary>
+    public static CelValue Of(bool value) => new(CelKind.Bool, value);
+
+    /// <summary>Wraps a timestamp value.</summary>
+    public static CelValue Of(DateTimeOffset value) => new(CelKind.Timestamp, value);
+
+    /// <summary>Wraps a list of values.</summary>
+    public static CelValue List(IReadOnlyList<CelValue> items) => new(CelKind.List, items);
+
+    /// <summary>True when this is the null/unset value.</summary>
+    public bool IsNull => Kind == CelKind.Null;
+
+    /// <summary>Gets the underlying string (only valid when <see cref="Kind"/> is String).</summary>
+    public string AsString() => (string)_value!;
+
+    /// <summary>Gets the underlying number (only valid when <see cref="Kind"/> is Number).</summary>
+    public double AsNumber() => (double)_value!;
+
+    /// <summary>Gets the underlying boolean (only valid when <see cref="Kind"/> is Bool).</summary>
+    public bool AsBool() => (bool)_value!;
+
+    /// <summary>Gets the underlying timestamp (only valid when <see cref="Kind"/> is Timestamp).</summary>
+    public DateTimeOffset AsTimestamp() => (DateTimeOffset)_value!;
+
+    /// <summary>Gets the underlying list (only valid when <see cref="Kind"/> is List).</summary>
+    public IReadOnlyList<CelValue> AsList() => (IReadOnlyList<CelValue>)_value!;
+
+    /// <summary>
+    /// CEL "truthiness" for use where a boolean is required (e.g. <c>exprHidden</c>):
+    /// a real bool; otherwise a non-empty string, a non-zero number, or a non-empty list.
+    /// </summary>
+    public bool IsTruthy => Kind switch
+    {
+        CelKind.Bool => AsBool(),
+        CelKind.String => AsString().Length > 0,
+        CelKind.Number => AsNumber() != 0,
+        CelKind.List => AsList().Count > 0,
+        CelKind.Timestamp => true,
+        _ => false,
+    };
+
+    /// <summary>A stable, culture-invariant string rendering (used by <c>string(...)</c> and concatenation).</summary>
+    public string ToDisplayString() => Kind switch
+    {
+        CelKind.Null => string.Empty,
+        CelKind.String => AsString(),
+        CelKind.Bool => AsBool() ? "true" : "false",
+        CelKind.Number => AsNumber().ToString("0.###############", CultureInfo.InvariantCulture),
+        CelKind.Timestamp => AsTimestamp().ToString("o", CultureInfo.InvariantCulture),
+        CelKind.List => "[" + string.Join(", ", AsList().Select(v => v.ToDisplayString())) + "]",
+        _ => string.Empty,
+    };
+
+    /// <summary>Debug rendering as <c>Kind:value</c>.</summary>
+    public override string ToString() => $"{Kind}:{ToDisplayString()}";
+}

--- a/src/PromptResponse.Core/Expressions/DictionaryExpressionContext.cs
+++ b/src/PromptResponse.Core/Expressions/DictionaryExpressionContext.cs
@@ -1,0 +1,56 @@
+namespace PromptResponse.Core.Expressions;
+
+/// <summary>
+/// A simple <see cref="IExpressionContext"/> backed by dictionaries: prompt ids
+/// → response strings, the <c>_this</c>/<c>_today</c> built-ins, and an optional
+/// <c>ctx.*</c> map keyed by dotted path (e.g. <c>"user.role"</c> for
+/// <c>ctx.user.role</c>). Unknown names resolve to <see cref="CelValue.Null"/>.
+/// </summary>
+public sealed class DictionaryExpressionContext : IExpressionContext
+{
+    private readonly IReadOnlyDictionary<string, string> _fields;
+    private readonly IReadOnlyDictionary<string, string>? _ctx;
+    private readonly string? _thisValue;
+    private readonly string? _today;
+
+    /// <summary>
+    /// Creates the context.
+    /// </summary>
+    /// <param name="fields">Prompt id → response string.</param>
+    /// <param name="thisValue">Value of <c>_this</c> (the current prompt's response).</param>
+    /// <param name="today">Value of <c>_today</c> (an ISO date string for <c>timestamp(_today)</c>).</param>
+    /// <param name="ctx">Context values keyed by dotted path under <c>ctx</c> (e.g. "user.role").</param>
+    public DictionaryExpressionContext(
+        IReadOnlyDictionary<string, string> fields,
+        string? thisValue = null,
+        string? today = null,
+        IReadOnlyDictionary<string, string>? ctx = null)
+    {
+        _fields = fields ?? throw new ArgumentNullException(nameof(fields));
+        _thisValue = thisValue;
+        _today = today;
+        _ctx = ctx;
+    }
+
+    /// <inheritdoc />
+    public CelValue Resolve(string name)
+    {
+        switch (name)
+        {
+            case "_this":
+                return _thisValue is null ? CelValue.Null : CelValue.Of(_thisValue);
+            case "_today":
+                return _today is null ? CelValue.Null : CelValue.Of(_today);
+            case "ctx":
+                return CelValue.Null; // the bare namespace is not itself a value
+        }
+
+        if (name.StartsWith("ctx.", StringComparison.Ordinal))
+        {
+            var key = name["ctx.".Length..];
+            return _ctx != null && _ctx.TryGetValue(key, out var cv) ? CelValue.Of(cv) : CelValue.Null;
+        }
+
+        return _fields.TryGetValue(name, out var fv) ? CelValue.Of(fv) : CelValue.Null;
+    }
+}

--- a/src/PromptResponse.Core/Expressions/Evaluator.cs
+++ b/src/PromptResponse.Core/Expressions/Evaluator.cs
@@ -1,0 +1,202 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace PromptResponse.Core.Expressions;
+
+/// <summary>
+/// Tree-walking evaluator for the CEL subset. Operators are type-checked;
+/// <c>matches()</c> runs with a timeout to defuse catastrophic-backtracking
+/// regexes. No loops, no user functions, no side effects.
+/// </summary>
+internal sealed class Evaluator
+{
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(250);
+
+    private readonly IExpressionContext _ctx;
+
+    public Evaluator(IExpressionContext ctx) => _ctx = ctx;
+
+    public CelValue Eval(Node node) => node switch
+    {
+        LiteralNode n => n.Value,
+        IdentifierNode n => _ctx.Resolve(n.Name),
+        MemberNode n => _ctx.Resolve(DottedPath(n)),
+        ListNode n => CelValue.List(n.Items.Select(Eval).ToList()),
+        UnaryNode n => EvalUnary(n),
+        BinaryNode n => EvalBinary(n),
+        TernaryNode n => Eval(n.Cond).IsTruthy ? Eval(n.IfTrue) : Eval(n.IfFalse),
+        CallNode n => EvalCall(n),
+        _ => throw new ExpressionException("Unknown expression node."),
+    };
+
+    private static string DottedPath(Node node) => node switch
+    {
+        IdentifierNode i => i.Name,
+        MemberNode m => DottedPath(m.Target) + "." + m.Name,
+        _ => throw new ExpressionException("Member access is only supported on names (e.g. ctx.a.b)."),
+    };
+
+    private CelValue EvalUnary(UnaryNode n)
+    {
+        var v = Eval(n.Operand);
+        return n.Op switch
+        {
+            TokType.Not => CelValue.Of(!v.IsTruthy),
+            TokType.Minus => CelValue.Of(-Num(v)),
+            _ => throw new ExpressionException("Bad unary operator."),
+        };
+    }
+
+    private CelValue EvalBinary(BinaryNode n)
+    {
+        // Short-circuit logicals.
+        if (n.Op == TokType.And)
+        {
+            return CelValue.Of(Eval(n.Left).IsTruthy && Eval(n.Right).IsTruthy);
+        }
+        if (n.Op == TokType.Or)
+        {
+            return CelValue.Of(Eval(n.Left).IsTruthy || Eval(n.Right).IsTruthy);
+        }
+
+        var a = Eval(n.Left);
+        var b = Eval(n.Right);
+
+        switch (n.Op)
+        {
+            case TokType.Eq: return CelValue.Of(AreEqual(a, b));
+            case TokType.Ne: return CelValue.Of(!AreEqual(a, b));
+            case TokType.Lt: return CelValue.Of(Compare(a, b) < 0);
+            case TokType.Le: return CelValue.Of(Compare(a, b) <= 0);
+            case TokType.Gt: return CelValue.Of(Compare(a, b) > 0);
+            case TokType.Ge: return CelValue.Of(Compare(a, b) >= 0);
+            case TokType.Plus: return Add(a, b);
+            case TokType.Minus: return CelValue.Of(Num(a) - Num(b));
+            case TokType.Star: return CelValue.Of(Num(a) * Num(b));
+            case TokType.Slash:
+                if (Num(b) == 0) throw new ExpressionException("Division by zero.");
+                return CelValue.Of(Num(a) / Num(b));
+            case TokType.Percent:
+                if (Num(b) == 0) throw new ExpressionException("Modulo by zero.");
+                return CelValue.Of(Num(a) % Num(b));
+            default: throw new ExpressionException("Bad binary operator.");
+        }
+    }
+
+    private static CelValue Add(CelValue a, CelValue b)
+    {
+        if (a.Kind == CelKind.Number && b.Kind == CelKind.Number) return CelValue.Of(a.AsNumber() + b.AsNumber());
+        if (a.Kind == CelKind.String && b.Kind == CelKind.String) return CelValue.Of(a.AsString() + b.AsString());
+        if (a.Kind == CelKind.List && b.Kind == CelKind.List)
+        {
+            return CelValue.List(a.AsList().Concat(b.AsList()).ToList());
+        }
+        throw new ExpressionException($"Cannot add {a.Kind} and {b.Kind}.");
+    }
+
+    private static bool AreEqual(CelValue a, CelValue b)
+    {
+        if (a.Kind != b.Kind) return false;
+        return a.Kind switch
+        {
+            CelKind.Null => true,
+            CelKind.String => a.AsString() == b.AsString(),
+            CelKind.Number => a.AsNumber() == b.AsNumber(),
+            CelKind.Bool => a.AsBool() == b.AsBool(),
+            CelKind.Timestamp => a.AsTimestamp() == b.AsTimestamp(),
+            CelKind.List => a.AsList().Count == b.AsList().Count &&
+                            a.AsList().Zip(b.AsList(), AreEqual).All(x => x),
+            _ => false,
+        };
+    }
+
+    private static int Compare(CelValue a, CelValue b)
+    {
+        if (a.Kind == CelKind.Number && b.Kind == CelKind.Number) return a.AsNumber().CompareTo(b.AsNumber());
+        if (a.Kind == CelKind.String && b.Kind == CelKind.String) return string.CompareOrdinal(a.AsString(), b.AsString());
+        if (a.Kind == CelKind.Timestamp && b.Kind == CelKind.Timestamp) return a.AsTimestamp().CompareTo(b.AsTimestamp());
+        throw new ExpressionException($"Cannot compare {a.Kind} and {b.Kind}.");
+    }
+
+    private static double Num(CelValue v) => v.Kind == CelKind.Number
+        ? v.AsNumber()
+        : throw new ExpressionException($"Expected a number but got {v.Kind}.");
+
+    private CelValue EvalCall(CallNode n)
+    {
+        CelValue Arg(int i) => Eval(n.Args[i]);
+        void Arity(int count)
+        {
+            if (n.Args.Count != count)
+            {
+                throw new ExpressionException($"{n.Function}() expects {count} argument(s).");
+            }
+        }
+
+        switch (n.Function)
+        {
+            case "int":
+                Arity(1);
+                return CelValue.Of(Math.Truncate(ToNumber(Arg(0), "int")));
+            case "double":
+                Arity(1);
+                return CelValue.Of(ToNumber(Arg(0), "double"));
+            case "string":
+                Arity(1);
+                return CelValue.Of(Arg(0).ToDisplayString());
+            case "size":
+                Arity(1);
+                var s = Arg(0);
+                return s.Kind switch
+                {
+                    CelKind.String => CelValue.Of((double)s.AsString().Length),
+                    CelKind.List => CelValue.Of((double)s.AsList().Count),
+                    _ => throw new ExpressionException("size() expects a string or list."),
+                };
+            case "matches":
+                Arity(2);
+                var input = Arg(0);
+                var pattern = Arg(1);
+                if (input.Kind != CelKind.String || pattern.Kind != CelKind.String)
+                {
+                    throw new ExpressionException("matches() expects (string, string).");
+                }
+                try
+                {
+                    return CelValue.Of(Regex.IsMatch(input.AsString(), pattern.AsString(), RegexOptions.None, RegexTimeout));
+                }
+                catch (RegexMatchTimeoutException)
+                {
+                    throw new ExpressionException("matches() regex timed out.");
+                }
+                catch (ArgumentException ex)
+                {
+                    throw new ExpressionException("matches() invalid regex.", ex);
+                }
+            case "timestamp":
+                Arity(1);
+                return CelValue.Of(ParseTimestamp(Arg(0)));
+            default:
+                throw new ExpressionException($"Unknown function '{n.Function}'.");
+        }
+    }
+
+    private static double ToNumber(CelValue v, string fn) => v.Kind switch
+    {
+        CelKind.Number => v.AsNumber(),
+        CelKind.String when double.TryParse(v.AsString().Trim(), NumberStyles.Any, CultureInfo.InvariantCulture, out var d) => d,
+        _ => throw new ExpressionException($"{fn}() cannot convert '{v.ToDisplayString()}' to a number."),
+    };
+
+    private static DateTimeOffset ParseTimestamp(CelValue v)
+    {
+        if (v.Kind == CelKind.Timestamp) return v.AsTimestamp();
+        if (v.Kind == CelKind.String &&
+            DateTimeOffset.TryParse(v.AsString().Trim(), CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var ts))
+        {
+            return ts;
+        }
+        throw new ExpressionException($"timestamp() cannot parse '{v.ToDisplayString()}'.");
+    }
+}

--- a/src/PromptResponse.Core/Expressions/ExpressionEvaluator.cs
+++ b/src/PromptResponse.Core/Expressions/ExpressionEvaluator.cs
@@ -1,0 +1,96 @@
+namespace PromptResponse.Core.Expressions;
+
+/// <summary>
+/// A parsed, reusable expression. Compile once, evaluate many times against
+/// different <see cref="IExpressionContext"/> snapshots (cheap and allocation-light).
+/// </summary>
+public sealed class CelExpression
+{
+    private readonly Node _root;
+
+    internal CelExpression(Node root) => _root = root;
+
+    /// <summary>Evaluates to a typed value. Throws <see cref="ExpressionException"/> on a type/eval error.</summary>
+    public CelValue Evaluate(IExpressionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return new Evaluator(context).Eval(_root);
+    }
+
+    /// <summary>
+    /// Evaluates to a boolean (CEL truthiness), returning <paramref name="fallback"/>
+    /// if the expression errors — so a broken <c>exprHidden</c>/<c>exprExpected</c>
+    /// never blocks the form.
+    /// </summary>
+    public bool EvaluateBool(IExpressionContext context, bool fallback = false)
+    {
+        try
+        {
+            return Evaluate(context).IsTruthy;
+        }
+        catch (ExpressionException)
+        {
+            return fallback;
+        }
+    }
+
+    /// <summary>Evaluates to a display string, returning <paramref name="fallback"/> on error.</summary>
+    public string EvaluateString(IExpressionContext context, string fallback = "")
+    {
+        try
+        {
+            return Evaluate(context).ToDisplayString();
+        }
+        catch (ExpressionException)
+        {
+            return fallback;
+        }
+    }
+}
+
+/// <summary>
+/// Compiles and evaluates expressions in the spec's CEL subset (Appendix B/C):
+/// prompt ids are variables holding response strings, with <c>_this</c>/<c>_today</c>
+/// built-ins and <c>ctx.*</c> context. Pure data — no code execution, bounded
+/// nesting/length, regex timeouts.
+/// </summary>
+public static class ExpressionEvaluator
+{
+    /// <summary>Maximum source length accepted, as a denial-of-service guard.</summary>
+    public const int MaxExpressionLength = 4000;
+
+    /// <summary>Parses an expression into a reusable <see cref="CelExpression"/>.</summary>
+    /// <exception cref="ExpressionException">On a syntax error or limit breach.</exception>
+    public static CelExpression Compile(string expression)
+    {
+        ArgumentNullException.ThrowIfNull(expression);
+        if (expression.Length > MaxExpressionLength)
+        {
+            throw new ExpressionException($"Expression exceeds the {MaxExpressionLength}-character limit.");
+        }
+
+        var tokens = new Lexer(expression).Tokenize();
+        var root = new Parser(tokens).ParseProgram();
+        return new CelExpression(root);
+    }
+
+    /// <summary>Compiles and evaluates in one call.</summary>
+    public static CelValue Evaluate(string expression, IExpressionContext context) =>
+        Compile(expression).Evaluate(context);
+
+    /// <summary>
+    /// Convenience: evaluate to bool with graceful fallback (used by visibility /
+    /// required hints). Compile errors also fall back.
+    /// </summary>
+    public static bool EvaluateBool(string expression, IExpressionContext context, bool fallback = false)
+    {
+        try
+        {
+            return Compile(expression).EvaluateBool(context, fallback);
+        }
+        catch (ExpressionException)
+        {
+            return fallback;
+        }
+    }
+}

--- a/src/PromptResponse.Core/Expressions/ExpressionException.cs
+++ b/src/PromptResponse.Core/Expressions/ExpressionException.cs
@@ -1,0 +1,23 @@
+namespace PromptResponse.Core.Expressions;
+
+/// <summary>
+/// Thrown when an expression cannot be parsed or evaluated (syntax error, type
+/// error, unknown function, or a safety limit being exceeded).
+/// </summary>
+/// <remarks>
+/// Callers that drive UI hints (e.g. <c>exprHidden</c>) should catch this and
+/// fall back to a safe default rather than surfacing a hard error — a broken
+/// hint must never block the user from filling the form.
+/// </remarks>
+public sealed class ExpressionException : Exception
+{
+    /// <summary>Creates the exception with a message.</summary>
+    public ExpressionException(string message) : base(message)
+    {
+    }
+
+    /// <summary>Creates the exception with a message and an inner cause.</summary>
+    public ExpressionException(string message, Exception inner) : base(message, inner)
+    {
+    }
+}

--- a/src/PromptResponse.Core/Expressions/IExpressionContext.cs
+++ b/src/PromptResponse.Core/Expressions/IExpressionContext.cs
@@ -1,0 +1,21 @@
+namespace PromptResponse.Core.Expressions;
+
+/// <summary>
+/// Resolves the variables an expression references. Per the spec, each prompt id
+/// is a variable holding its response string; <c>_this</c> is the current
+/// prompt's value, <c>_today</c> is today's date, and <c>ctx.*</c> reaches the
+/// optional filler-provided context.
+/// </summary>
+/// <remarks>
+/// Resolution must be side-effect free. A missing variable returns
+/// <see cref="CelValue.Null"/> so expressions degrade gracefully (the spec
+/// requires expressions to tolerate missing context) rather than throwing.
+/// </remarks>
+public interface IExpressionContext
+{
+    /// <summary>
+    /// Resolves a top-level name (a prompt id, a built-in like <c>_this</c>/<c>_today</c>,
+    /// or the <c>ctx</c> root). Returns <see cref="CelValue.Null"/> when unknown.
+    /// </summary>
+    CelValue Resolve(string name);
+}

--- a/src/PromptResponse.Core/Expressions/Lexer.cs
+++ b/src/PromptResponse.Core/Expressions/Lexer.cs
@@ -1,0 +1,180 @@
+using System.Globalization;
+using System.Text;
+
+namespace PromptResponse.Core.Expressions;
+
+internal enum TokType
+{
+    Number, String, Identifier, True, False, Null,
+    Plus, Minus, Star, Slash, Percent,
+    Eq, Ne, Lt, Le, Gt, Ge,
+    And, Or, Not,
+    Question, Colon, Comma, Dot,
+    LParen, RParen, LBracket, RBracket,
+    End,
+}
+
+internal readonly record struct Token(TokType Type, string Text, CelValue Value);
+
+/// <summary>
+/// Tokenizes an expression string into the CEL subset's tokens. Pure; throws
+/// <see cref="ExpressionException"/> on an illegal character or unterminated
+/// string.
+/// </summary>
+internal sealed class Lexer
+{
+    private readonly string _src;
+    private int _pos;
+
+    public Lexer(string src) => _src = src;
+
+    public List<Token> Tokenize()
+    {
+        var tokens = new List<Token>();
+        Token t;
+        do
+        {
+            t = Next();
+            tokens.Add(t);
+        }
+        while (t.Type != TokType.End);
+        return tokens;
+    }
+
+    private char Cur => _pos < _src.Length ? _src[_pos] : '\0';
+    private char Peek => _pos + 1 < _src.Length ? _src[_pos + 1] : '\0';
+
+    private Token Next()
+    {
+        while (_pos < _src.Length && char.IsWhiteSpace(Cur))
+        {
+            _pos++;
+        }
+        if (_pos >= _src.Length)
+        {
+            return new Token(TokType.End, string.Empty, CelValue.Null);
+        }
+
+        var c = Cur;
+        if (char.IsDigit(c) || (c == '.' && char.IsDigit(Peek)))
+        {
+            return Number();
+        }
+        if (c == '\'' || c == '"')
+        {
+            return Str(c);
+        }
+        if (char.IsLetter(c) || c == '_')
+        {
+            return Ident();
+        }
+        return Operator();
+    }
+
+    private Token Number()
+    {
+        var start = _pos;
+        while (char.IsDigit(Cur))
+        {
+            _pos++;
+        }
+        if (Cur == '.')
+        {
+            _pos++;
+            while (char.IsDigit(Cur))
+            {
+                _pos++;
+            }
+        }
+        var text = _src[start.._pos];
+        var num = double.Parse(text, CultureInfo.InvariantCulture);
+        return new Token(TokType.Number, text, CelValue.Of(num));
+    }
+
+    private Token Str(char quote)
+    {
+        _pos++; // opening quote
+        var sb = new StringBuilder();
+        while (_pos < _src.Length && Cur != quote)
+        {
+            if (Cur == '\\')
+            {
+                _pos++;
+                sb.Append(Cur switch
+                {
+                    'n' => '\n',
+                    't' => '\t',
+                    'r' => '\r',
+                    '\\' => '\\',
+                    '\'' => '\'',
+                    '"' => '"',
+                    _ => Cur,
+                });
+                _pos++;
+            }
+            else
+            {
+                sb.Append(Cur);
+                _pos++;
+            }
+        }
+        if (_pos >= _src.Length)
+        {
+            throw new ExpressionException("Unterminated string literal.");
+        }
+        _pos++; // closing quote
+        return new Token(TokType.String, sb.ToString(), CelValue.Of(sb.ToString()));
+    }
+
+    private Token Ident()
+    {
+        var start = _pos;
+        while (char.IsLetterOrDigit(Cur) || Cur == '_')
+        {
+            _pos++;
+        }
+        var text = _src[start.._pos];
+        return text switch
+        {
+            "true" => new Token(TokType.True, text, CelValue.Of(true)),
+            "false" => new Token(TokType.False, text, CelValue.Of(false)),
+            "null" => new Token(TokType.Null, text, CelValue.Null),
+            _ => new Token(TokType.Identifier, text, CelValue.Null),
+        };
+    }
+
+    private Token Operator()
+    {
+        var c = Cur;
+        var n = Peek;
+        switch (c)
+        {
+            case '+': _pos++; return Tok(TokType.Plus, "+");
+            case '-': _pos++; return Tok(TokType.Minus, "-");
+            case '*': _pos++; return Tok(TokType.Star, "*");
+            case '/': _pos++; return Tok(TokType.Slash, "/");
+            case '%': _pos++; return Tok(TokType.Percent, "%");
+            case '?': _pos++; return Tok(TokType.Question, "?");
+            case ':': _pos++; return Tok(TokType.Colon, ":");
+            case ',': _pos++; return Tok(TokType.Comma, ",");
+            case '.': _pos++; return Tok(TokType.Dot, ".");
+            case '(': _pos++; return Tok(TokType.LParen, "(");
+            case ')': _pos++; return Tok(TokType.RParen, ")");
+            case '[': _pos++; return Tok(TokType.LBracket, "[");
+            case ']': _pos++; return Tok(TokType.RBracket, "]");
+            case '=' when n == '=': _pos += 2; return Tok(TokType.Eq, "==");
+            case '!' when n == '=': _pos += 2; return Tok(TokType.Ne, "!=");
+            case '<' when n == '=': _pos += 2; return Tok(TokType.Le, "<=");
+            case '>' when n == '=': _pos += 2; return Tok(TokType.Ge, ">=");
+            case '<': _pos++; return Tok(TokType.Lt, "<");
+            case '>': _pos++; return Tok(TokType.Gt, ">");
+            case '&' when n == '&': _pos += 2; return Tok(TokType.And, "&&");
+            case '|' when n == '|': _pos += 2; return Tok(TokType.Or, "||");
+            case '!': _pos++; return Tok(TokType.Not, "!");
+            default:
+                throw new ExpressionException($"Unexpected character '{c}' in expression.");
+        }
+    }
+
+    private static Token Tok(TokType type, string text) => new(type, text, CelValue.Null);
+}

--- a/src/PromptResponse.Core/Expressions/Parser.cs
+++ b/src/PromptResponse.Core/Expressions/Parser.cs
@@ -1,0 +1,245 @@
+namespace PromptResponse.Core.Expressions;
+
+internal abstract record Node;
+internal sealed record LiteralNode(CelValue Value) : Node;
+internal sealed record IdentifierNode(string Name) : Node;
+internal sealed record ListNode(IReadOnlyList<Node> Items) : Node;
+internal sealed record MemberNode(Node Target, string Name) : Node;
+internal sealed record CallNode(string Function, IReadOnlyList<Node> Args) : Node;
+internal sealed record UnaryNode(TokType Op, Node Operand) : Node;
+internal sealed record BinaryNode(TokType Op, Node Left, Node Right) : Node;
+internal sealed record TernaryNode(Node Cond, Node IfTrue, Node IfFalse) : Node;
+
+/// <summary>
+/// Recursive-descent parser for the CEL subset. Precedence (low → high):
+/// ternary, <c>||</c>, <c>&amp;&amp;</c>, equality, comparison, additive,
+/// multiplicative, unary, primary. Depth-limited to bound the work an
+/// adversarial expression can cause.
+/// </summary>
+internal sealed class Parser
+{
+    private const int MaxDepth = 64;
+
+    private readonly List<Token> _tokens;
+    private int _pos;
+    private int _depth;
+
+    public Parser(List<Token> tokens) => _tokens = tokens;
+
+    public Node ParseProgram()
+    {
+        var node = ParseTernary();
+        if (Cur.Type != TokType.End)
+        {
+            throw new ExpressionException($"Unexpected token '{Cur.Text}' after expression.");
+        }
+        return node;
+    }
+
+    private Token Cur => _tokens[_pos];
+
+    private Token Advance() => _tokens[_pos++];
+
+    private bool Match(TokType type)
+    {
+        if (Cur.Type == type)
+        {
+            _pos++;
+            return true;
+        }
+        return false;
+    }
+
+    private void Expect(TokType type, string what)
+    {
+        if (!Match(type))
+        {
+            throw new ExpressionException($"Expected {what} but found '{Cur.Text}'.");
+        }
+    }
+
+    private IDisposable Deepen()
+    {
+        if (++_depth > MaxDepth)
+        {
+            throw new ExpressionException("Expression nesting too deep.");
+        }
+        return new DepthScope(this);
+    }
+
+    private sealed class DepthScope(Parser p) : IDisposable
+    {
+        public void Dispose() => p._depth--;
+    }
+
+    private Node ParseTernary()
+    {
+        using var _ = Deepen();
+        var cond = ParseOr();
+        if (Match(TokType.Question))
+        {
+            var ifTrue = ParseTernary();
+            Expect(TokType.Colon, "':'");
+            var ifFalse = ParseTernary();
+            return new TernaryNode(cond, ifTrue, ifFalse);
+        }
+        return cond;
+    }
+
+    private Node ParseOr()
+    {
+        var left = ParseAnd();
+        while (Cur.Type == TokType.Or)
+        {
+            Advance();
+            left = new BinaryNode(TokType.Or, left, ParseAnd());
+        }
+        return left;
+    }
+
+    private Node ParseAnd()
+    {
+        var left = ParseEquality();
+        while (Cur.Type == TokType.And)
+        {
+            Advance();
+            left = new BinaryNode(TokType.And, left, ParseEquality());
+        }
+        return left;
+    }
+
+    private Node ParseEquality()
+    {
+        var left = ParseComparison();
+        while (Cur.Type is TokType.Eq or TokType.Ne)
+        {
+            var op = Advance().Type;
+            left = new BinaryNode(op, left, ParseComparison());
+        }
+        return left;
+    }
+
+    private Node ParseComparison()
+    {
+        var left = ParseAdditive();
+        while (Cur.Type is TokType.Lt or TokType.Le or TokType.Gt or TokType.Ge)
+        {
+            var op = Advance().Type;
+            left = new BinaryNode(op, left, ParseAdditive());
+        }
+        return left;
+    }
+
+    private Node ParseAdditive()
+    {
+        var left = ParseMultiplicative();
+        while (Cur.Type is TokType.Plus or TokType.Minus)
+        {
+            var op = Advance().Type;
+            left = new BinaryNode(op, left, ParseMultiplicative());
+        }
+        return left;
+    }
+
+    private Node ParseMultiplicative()
+    {
+        var left = ParseUnary();
+        while (Cur.Type is TokType.Star or TokType.Slash or TokType.Percent)
+        {
+            var op = Advance().Type;
+            left = new BinaryNode(op, left, ParseUnary());
+        }
+        return left;
+    }
+
+    private Node ParseUnary()
+    {
+        if (Cur.Type is TokType.Not or TokType.Minus)
+        {
+            var op = Advance().Type;
+            return new UnaryNode(op, ParseUnary());
+        }
+        return ParsePostfix();
+    }
+
+    private Node ParsePostfix()
+    {
+        var node = ParsePrimary();
+        while (Match(TokType.Dot))
+        {
+            if (Cur.Type != TokType.Identifier)
+            {
+                throw new ExpressionException("Expected a name after '.'.");
+            }
+            node = new MemberNode(node, Advance().Text);
+        }
+        return node;
+    }
+
+    private Node ParsePrimary()
+    {
+        using var _ = Deepen();
+        var t = Cur;
+        switch (t.Type)
+        {
+            case TokType.Number:
+            case TokType.String:
+            case TokType.True:
+            case TokType.False:
+            case TokType.Null:
+                Advance();
+                return new LiteralNode(t.Value);
+
+            case TokType.Identifier:
+                Advance();
+                if (Match(TokType.LParen))
+                {
+                    return new CallNode(t.Text, ParseArguments());
+                }
+                return new IdentifierNode(t.Text);
+
+            case TokType.LParen:
+                Advance();
+                var inner = ParseTernary();
+                Expect(TokType.RParen, "')'");
+                return inner;
+
+            case TokType.LBracket:
+                Advance();
+                return new ListNode(ParseList());
+
+            default:
+                throw new ExpressionException($"Unexpected token '{t.Text}'.");
+        }
+    }
+
+    private List<Node> ParseArguments()
+    {
+        var args = new List<Node>();
+        if (Cur.Type != TokType.RParen)
+        {
+            do
+            {
+                args.Add(ParseTernary());
+            }
+            while (Match(TokType.Comma));
+        }
+        Expect(TokType.RParen, "')'");
+        return args;
+    }
+
+    private List<Node> ParseList()
+    {
+        var items = new List<Node>();
+        if (Cur.Type != TokType.RBracket)
+        {
+            do
+            {
+                items.Add(ParseTernary());
+            }
+            while (Match(TokType.Comma));
+        }
+        Expect(TokType.RBracket, "']'");
+        return items;
+    }
+}

--- a/tests/PromptResponse.Core.Tests/Expressions/ExpressionEvaluatorTests.cs
+++ b/tests/PromptResponse.Core.Tests/Expressions/ExpressionEvaluatorTests.cs
@@ -1,0 +1,196 @@
+using AwesomeAssertions;
+using PromptResponse.Core.Expressions;
+using Xunit;
+
+namespace PromptResponse.Core.Tests.Expressions;
+
+/// <summary>
+/// Verifies the safe CEL-subset expression evaluator: literals, operators,
+/// precedence, field references, built-in functions, graceful handling of
+/// missing variables, and the safety limits.
+/// </summary>
+public class ExpressionEvaluatorTests
+{
+    private static IExpressionContext Ctx(
+        Dictionary<string, string>? fields = null,
+        string? thisValue = null,
+        string? today = null,
+        Dictionary<string, string>? ctx = null) =>
+        new DictionaryExpressionContext(fields ?? new(), thisValue, today, ctx);
+
+    private static CelValue Eval(string expr, IExpressionContext? ctx = null) =>
+        ExpressionEvaluator.Evaluate(expr, ctx ?? Ctx());
+
+    [Theory]
+    [InlineData("1 + 2", 3)]
+    [InlineData("2 * 3 + 4", 10)]       // precedence
+    [InlineData("2 + 3 * 4", 14)]
+    [InlineData("(2 + 3) * 4", 20)]
+    [InlineData("10 / 4", 2.5)]
+    [InlineData("10 % 3", 1)]
+    [InlineData("-5 + 8", 3)]
+    public void Arithmetic(string expr, double expected) =>
+        Eval(expr).AsNumber().Should().Be(expected);
+
+    [Theory]
+    [InlineData("1 < 2", true)]
+    [InlineData("2 <= 2", true)]
+    [InlineData("3 > 5", false)]
+    [InlineData("'a' < 'b'", true)]
+    [InlineData("'Employed' == 'Employed'", true)]
+    [InlineData("'a' != 'b'", true)]
+    [InlineData("true && false", false)]
+    [InlineData("true || false", true)]
+    [InlineData("!false", true)]
+    [InlineData("1 == 1 ? true : false", true)]
+    public void BooleanLogic(string expr, bool expected) =>
+        Eval(expr).AsBool().Should().Be(expected);
+
+    [Fact]
+    public void FieldReference_ResolvesResponseString()
+    {
+        var ctx = Ctx(new() { ["emp_status"] = "Employed" });
+        Eval("emp_status == 'Employed'", ctx).AsBool().Should().BeTrue();
+        Eval("emp_status", ctx).AsString().Should().Be("Employed");
+    }
+
+    [Fact]
+    public void MissingField_ResolvesToNull_AndComparesAsNotEqual()
+    {
+        // "missing" field → Null; Null == 'x' is false (graceful, no throw).
+        Eval("nope == 'x'", Ctx()).AsBool().Should().BeFalse();
+        Eval("nope", Ctx()).IsNull.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("int('18') >= 18", true)]
+    [InlineData("int('17') >= 18", false)]
+    [InlineData("double('50000.5') > 50000.0", true)]
+    [InlineData("size('hello') == 5", true)]
+    [InlineData("size('') > 0", false)]
+    [InlineData("matches('abc-123', '^[a-z]+-[0-9]+$')", true)]
+    [InlineData("matches('ABC', '^[a-z]+$')", false)]
+    [InlineData("string(42) == '42'", true)]
+    public void BuiltinFunctions(string expr, bool expected) =>
+        Eval(expr).AsBool().Should().Be(expected);
+
+    [Fact]
+    public void Timestamp_Comparison()
+    {
+        var ctx = Ctx(new() { ["start"] = "2020-01-15", ["end"] = "2021-06-01" });
+        Eval("timestamp(end) > timestamp(start)", ctx).AsBool().Should().BeTrue();
+    }
+
+    [Fact]
+    public void Today_BuiltinAndCtx()
+    {
+        var ctx = Ctx(
+            fields: new() { ["d"] = "2000-01-01" },
+            today: "2026-06-06",
+            ctx: new() { ["user.role"] = "admin" });
+
+        Eval("timestamp(d) < timestamp(_today)", ctx).AsBool().Should().BeTrue();
+        Eval("ctx.user.role == 'admin'", ctx).AsBool().Should().BeTrue();
+        Eval("ctx.user.missing == ''", ctx).AsBool().Should().BeFalse(); // missing ctx → Null, not ""
+    }
+
+    [Fact]
+    public void SpecExample_ConditionalVisibility()
+    {
+        var expr = "emp_status == 'Unemployed' || emp_status == 'Retired' || emp_status == 'Student'";
+        ExpressionEvaluator.EvaluateBool(expr, Ctx(new() { ["emp_status"] = "Student" })).Should().BeTrue();
+        ExpressionEvaluator.EvaluateBool(expr, Ctx(new() { ["emp_status"] = "Employed" })).Should().BeFalse();
+    }
+
+    [Fact]
+    public void SpecExample_CrossFieldValidation()
+    {
+        // empty when valid; message when end <= start
+        var expr = "_this == '' || start == '' ? '' : (timestamp(_this) > timestamp(start) ? '' : 'End date must be after start date')";
+
+        var ok = ExpressionEvaluator.Compile(expr)
+            .EvaluateString(Ctx(new() { ["start"] = "2020-01-01" }, thisValue: "2021-01-01"));
+        ok.Should().BeEmpty();
+
+        var bad = ExpressionEvaluator.Compile(expr)
+            .EvaluateString(Ctx(new() { ["start"] = "2021-01-01" }, thisValue: "2020-01-01"));
+        bad.Should().Be("End date must be after start date");
+    }
+
+    [Fact]
+    public void ListLiteral_AndSize()
+    {
+        Eval("size(['a', 'b', 'c'])").AsNumber().Should().Be(3);
+    }
+
+    [Fact]
+    public void StringConcatenation()
+    {
+        Eval("'Hello, ' + 'World'").AsString().Should().Be("Hello, World");
+    }
+
+    [Theory]
+    [InlineData("1 +")]              // incomplete
+    [InlineData("(1 + 2")]           // unbalanced paren
+    [InlineData("'unterminated")]    // bad string
+    [InlineData("1 @ 2")]            // illegal char
+    [InlineData("foo(")]             // bad call
+    public void SyntaxErrors_Throw(string expr)
+    {
+        var act = () => ExpressionEvaluator.Compile(expr);
+        act.Should().Throw<ExpressionException>();
+    }
+
+    [Theory]
+    [InlineData("1 / 0")]
+    [InlineData("5 % 0")]
+    [InlineData("'a' - 'b'")]        // type error
+    [InlineData("unknownFn(1)")]     // unknown function
+    [InlineData("int('not a number')")]
+    public void EvalErrors_Throw(string expr)
+    {
+        var act = () => Eval(expr);
+        act.Should().Throw<ExpressionException>();
+    }
+
+    [Fact]
+    public void EvaluateBool_OnError_FallsBackGracefully()
+    {
+        // A broken hint must never block the form — falls back, doesn't throw.
+        ExpressionEvaluator.EvaluateBool("1 / 0", Ctx(), fallback: false).Should().BeFalse();
+        ExpressionEvaluator.EvaluateBool("not valid syntax )(", Ctx(), fallback: true).Should().BeTrue();
+    }
+
+    [Fact]
+    public void OverlongExpression_IsRejected()
+    {
+        var huge = "1" + string.Concat(Enumerable.Repeat(" + 1", 2000));
+        var act = () => ExpressionEvaluator.Compile(huge);
+        act.Should().Throw<ExpressionException>();
+    }
+
+    [Fact]
+    public void DeeplyNestedExpression_IsRejected()
+    {
+        var deep = string.Concat(Enumerable.Repeat("(", 200)) + "1" + string.Concat(Enumerable.Repeat(")", 200));
+        var act = () => ExpressionEvaluator.Compile(deep);
+        act.Should().Throw<ExpressionException>();
+    }
+
+    [Fact]
+    public void ShortCircuit_DoesNotEvaluateRightOnFalseAnd()
+    {
+        // If && evaluated the right side, 1/0 would throw; short-circuit avoids it.
+        Eval("false && (1 / 0 == 0)").AsBool().Should().BeFalse();
+        Eval("true || (1 / 0 == 0)").AsBool().Should().BeTrue();
+    }
+
+    [Fact]
+    public void CompiledExpression_IsReusableAcrossContexts()
+    {
+        var compiled = ExpressionEvaluator.Compile("age == '' ? false : int(age) >= 18");
+        compiled.EvaluateBool(Ctx(new() { ["age"] = "20" })).Should().BeTrue();
+        compiled.EvaluateBool(Ctx(new() { ["age"] = "15" })).Should().BeFalse();
+        compiled.EvaluateBool(Ctx(new() { ["age"] = "" })).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
**Phase 1 of Milestone 2.** A pure-data evaluator for the spec's CEL subset (Appendix B/C) — the foundation for computed fields, conditional visibility, conditional-required, and cross-field validation.

- Prompt ids → response-string variables; `_this`/`_today` built-ins; `ctx.*` context.
- Functions: `int`/`double`/`timestamp`/`size`/`matches`/`string`. Operators: arithmetic, comparison, logical (short-circuit), ternary.
- **Honors no-code-execution**: whitelisted functions only, bounded nesting (64) + length (4000), `matches()` regex timeout (250ms, anti-ReDoS), missing vars → null so hints degrade gracefully.
- Lexer + recursive-descent parser + tree-walking evaluator; reusable `CelExpression`; `EvaluateBool`/`EvaluateString` with safe fallback so a broken hint never blocks the form.

**48 tests** (incl. the spec's conditional-visibility + cross-field-validation examples); Core **423 → 471**. Next: wire `expr*` hint fields into the format + reactive UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)