### PR TITLE
feat(core): expr* form hints + FormExpressions service (Milestone 2, Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Expression hints + form evaluation** — `PromptHints` gains `exprHidden`,
+  `exprValue`, `exprExpected`, `exprValidation`, `exprReadOnly` (CEL-subset
+  strings; round-trip through JSON). `FormExpressions` (Core) evaluates them
+  against live responses: conditional visibility, computed read-only values with
+  **fixpoint recompute** for chained totals (circular-safe), conditional-required,
+  and cross-field validation — all advisory, never blocking. Reactive desktop UI
+  wiring is the next phase. (Milestone 2)
 - **Expression engine** (`PromptResponse.Core.Expressions`) — a safe, pure-data
   evaluator for the spec's CEL subset (Appendix B/C): prompt ids are variables
   holding response strings, with `_this`/`_today` built-ins, `ctx.*` context, the

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -43,10 +43,10 @@ Cross-reference with ROADMAP.md for detailed descriptions.
 | JSON serialization | P0 | ✅ | camelCase, ISO 8601 dates |
 | Advisory validation | P0 | ✅ | Structural + data type |
 | Data type hints | P1 | ✅ | text, email, date, number, etc. |
-| Expression parser | P1 | ⏳ | Planned — not implemented; see `docs/APR_SPECIFICATION_v0.2.md` for forward-looking design |
+| Expression parser | P1 | ✅ | Safe CEL-subset evaluator in `PromptResponse.Core.Expressions` (no code execution) |
 | Undo/Redo system | P1 | ✅ | Command pattern implemented |
-| Calculation engine | P1 | ⏳ | Computed fields with formulas |
-| Conditional logic | P2 | ⏳ | Show/hide fields based on values |
+| Calculation engine | P1 | 🔄 | Computed fields (`exprValue`) with fixpoint recompute — Core done (`FormExpressions`); reactive UI pending |
+| Conditional logic | P2 | 🔄 | `exprHidden`/`exprExpected`/`exprValidation` — Core done (`FormExpressions`); reactive UI pending |
 
 ---
 

--- a/src/PromptResponse.Core/Expressions/FormExpressions.cs
+++ b/src/PromptResponse.Core/Expressions/FormExpressions.cs
@@ -1,0 +1,160 @@
+using PromptResponse.Core.Models;
+
+namespace PromptResponse.Core.Expressions;
+
+/// <summary>
+/// Evaluates a document's <c>expr*</c> hints against the current responses:
+/// conditional visibility, computed (read-only) values, conditional-expected,
+/// and cross-field validation. Pure and side-effect-free except
+/// <see cref="RecomputeComputedValues"/>, which writes derived values back.
+/// </summary>
+/// <remarks>
+/// Per the vision these are advisory: a broken expression falls back to a safe
+/// default (visible, not required, valid, unchanged) and never blocks input.
+/// </remarks>
+public static class FormExpressions
+{
+    /// <summary>All prompts in the document, in document order (sections recursed).</summary>
+    public static IReadOnlyList<Prompt> GetAllPrompts(AprDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        var list = new List<Prompt>();
+        foreach (var section in document.Sections)
+        {
+            Collect(section, list);
+        }
+        return list;
+    }
+
+    private static void Collect(Section section, List<Prompt> into)
+    {
+        into.AddRange(section.Prompts);
+        foreach (var child in section.Sections)
+        {
+            Collect(child, into);
+        }
+    }
+
+    /// <summary>Snapshot of prompt id → current response, the variable scope for expressions.</summary>
+    public static IReadOnlyDictionary<string, string> BuildFields(AprDocument document)
+    {
+        var fields = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var p in GetAllPrompts(document))
+        {
+            if (!string.IsNullOrEmpty(p.Id))
+            {
+                fields[p.Id] = p.Response;
+            }
+        }
+        return fields;
+    }
+
+    /// <summary>True when the prompt's <c>exprHidden</c> evaluates truthy (default: visible).</summary>
+    public static bool IsHidden(Prompt prompt, IReadOnlyDictionary<string, string> fields, string? today = null, IReadOnlyDictionary<string, string>? ctx = null) =>
+        EvalBool(prompt, prompt.Hints.ExprHidden, fields, today, ctx, fallback: false);
+
+    /// <summary>True when the prompt's <c>exprExpected</c> evaluates truthy (default: not required).</summary>
+    public static bool IsExpected(Prompt prompt, IReadOnlyDictionary<string, string> fields, string? today = null, IReadOnlyDictionary<string, string>? ctx = null) =>
+        EvalBool(prompt, prompt.Hints.ExprExpected, fields, today, ctx, fallback: false);
+
+    /// <summary>
+    /// True when the prompt is read-only: it has a computed value (<c>exprValue</c>)
+    /// or its <c>exprReadOnly</c> evaluates truthy.
+    /// </summary>
+    public static bool IsReadOnly(Prompt prompt, IReadOnlyDictionary<string, string> fields, string? today = null, IReadOnlyDictionary<string, string>? ctx = null) =>
+        !string.IsNullOrWhiteSpace(prompt.Hints.ExprValue)
+        || EvalBool(prompt, prompt.Hints.ExprReadOnly, fields, today, ctx, fallback: false);
+
+    /// <summary>
+    /// The cross-field validation message from <c>exprValidation</c>, or null when
+    /// there's no rule or the field is valid (empty result).
+    /// </summary>
+    public static string? Validate(Prompt prompt, IReadOnlyDictionary<string, string> fields, string? today = null, IReadOnlyDictionary<string, string>? ctx = null)
+    {
+        if (string.IsNullOrWhiteSpace(prompt.Hints.ExprValidation))
+        {
+            return null;
+        }
+        var message = EvalString(prompt, prompt.Hints.ExprValidation!, fields, today, ctx, fallback: string.Empty);
+        return string.IsNullOrEmpty(message) ? null : message;
+    }
+
+    /// <summary>
+    /// The computed value from <c>exprValue</c>, or null when the prompt isn't
+    /// computed. Errors fall back to the prompt's current response.
+    /// </summary>
+    public static string? ComputeValue(Prompt prompt, IReadOnlyDictionary<string, string> fields, string? today = null, IReadOnlyDictionary<string, string>? ctx = null)
+    {
+        if (string.IsNullOrWhiteSpace(prompt.Hints.ExprValue))
+        {
+            return null;
+        }
+        return EvalString(prompt, prompt.Hints.ExprValue!, fields, today, ctx, fallback: prompt.Response);
+    }
+
+    /// <summary>
+    /// Recomputes every computed field (<c>exprValue</c>) and writes the result
+    /// back to its response, iterating to a fixpoint so chained computations
+    /// (a total of subtotals) settle. Bounded to defuse circular references.
+    /// Returns true if any value changed.
+    /// </summary>
+    public static bool RecomputeComputedValues(AprDocument document, string? today = null, IReadOnlyDictionary<string, string>? ctx = null)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        var computed = GetAllPrompts(document)
+            .Where(p => !string.IsNullOrWhiteSpace(p.Hints.ExprValue))
+            .ToList();
+        if (computed.Count == 0)
+        {
+            return false;
+        }
+
+        var anyChanged = false;
+        // At most computed.Count+1 passes: each pass can settle at least one more
+        // field in a non-circular dependency graph; the extra pass confirms stability.
+        for (var pass = 0; pass <= computed.Count; pass++)
+        {
+            var fields = BuildFields(document);
+            var changedThisPass = false;
+            foreach (var p in computed)
+            {
+                var value = EvalString(p, p.Hints.ExprValue!, fields, today, ctx, fallback: p.Response);
+                if (value != p.Response)
+                {
+                    p.Response = value;
+                    changedThisPass = true;
+                    anyChanged = true;
+                }
+            }
+            if (!changedThisPass)
+            {
+                break;
+            }
+        }
+        return anyChanged;
+    }
+
+    private static IExpressionContext ContextFor(Prompt prompt, IReadOnlyDictionary<string, string> fields, string? today, IReadOnlyDictionary<string, string>? ctx) =>
+        new DictionaryExpressionContext(fields, thisValue: prompt.Response, today: today, ctx: ctx);
+
+    private static bool EvalBool(Prompt prompt, string? expr, IReadOnlyDictionary<string, string> fields, string? today, IReadOnlyDictionary<string, string>? ctx, bool fallback)
+    {
+        if (string.IsNullOrWhiteSpace(expr))
+        {
+            return fallback;
+        }
+        return ExpressionEvaluator.EvaluateBool(expr!, ContextFor(prompt, fields, today, ctx), fallback);
+    }
+
+    private static string EvalString(Prompt prompt, string expr, IReadOnlyDictionary<string, string> fields, string? today, IReadOnlyDictionary<string, string>? ctx, string fallback)
+    {
+        try
+        {
+            return ExpressionEvaluator.Compile(expr).EvaluateString(ContextFor(prompt, fields, today, ctx), fallback);
+        }
+        catch (ExpressionException)
+        {
+            return fallback;
+        }
+    }
+}

--- a/src/PromptResponse.Core/Models/PromptHints.cs
+++ b/src/PromptResponse.Core/Models/PromptHints.cs
@@ -59,4 +59,39 @@ public class PromptHints
     /// </example>
     public string? ValidationPattern { get; set; }
 
+    // ── Expression hints (CEL subset; see docs/APR_SPECIFICATION_v0.2.md Appendix B/C) ──
+    // All are advisory and pure-data: they transform display/visibility/validation,
+    // never block input, and never execute code. Evaluated by PromptResponse.Core.Expressions.
+
+    /// <summary>
+    /// Expression that, when truthy, hides this prompt (conditional visibility).
+    /// </summary>
+    /// <example>"emp_status == 'Retired' || emp_status == 'Student'"</example>
+    public string? ExprHidden { get; set; }
+
+    /// <summary>
+    /// Expression for a computed (read-only) value. When set, the field's value
+    /// is derived from this expression and recomputed as its dependencies change.
+    /// </summary>
+    /// <example>"double(qty) * double(price)"</example>
+    public string? ExprValue { get; set; }
+
+    /// <summary>
+    /// Expression that, when truthy, marks this prompt as expected/required
+    /// (advisory only — never blocks submission).
+    /// </summary>
+    /// <example>"emp_status == 'Employed'"</example>
+    public string? ExprExpected { get; set; }
+
+    /// <summary>
+    /// Cross-field validation expression returning a message string; an empty
+    /// string means "valid". Surfaced as an advisory, never blocking.
+    /// </summary>
+    /// <example>"timestamp(_this) &gt; timestamp(start) ? '' : 'Must be after start'"</example>
+    public string? ExprValidation { get; set; }
+
+    /// <summary>
+    /// Expression that, when truthy, makes this prompt read-only.
+    /// </summary>
+    public string? ExprReadOnly { get; set; }
 }

--- a/tests/PromptResponse.Core.Tests/Expressions/FormExpressionsTests.cs
+++ b/tests/PromptResponse.Core.Tests/Expressions/FormExpressionsTests.cs
@@ -1,0 +1,146 @@
+using AwesomeAssertions;
+using PromptResponse.Core.Expressions;
+using PromptResponse.Core.Models;
+using PromptResponse.Core.Serialization;
+using Xunit;
+
+namespace PromptResponse.Core.Tests.Expressions;
+
+/// <summary>
+/// Verifies the document-level expression service: conditional visibility,
+/// computed (read-only) values with fixpoint recompute, conditional-expected,
+/// and cross-field validation — plus that the new expr* hints round-trip.
+/// </summary>
+public class FormExpressionsTests
+{
+    private static AprDocument Doc(params Prompt[] prompts) => new()
+    {
+        Metadata = new Metadata { Title = "T" },
+        Sections = [new Section { Id = "s", Title = "S", Prompts = prompts.ToList() }],
+    };
+
+    [Fact]
+    public void IsHidden_RespondsToOtherFields()
+    {
+        var doc = Doc(
+            new Prompt { Id = "emp_status", Response = "Retired" },
+            new Prompt { Id = "employer", Hints = new PromptHints { ExprHidden = "emp_status == 'Retired' || emp_status == 'Student'" } });
+        var employer = FormExpressions.GetAllPrompts(doc)[1];
+
+        FormExpressions.IsHidden(employer, FormExpressions.BuildFields(doc)).Should().BeTrue();
+
+        doc.Sections[0].Prompts[0].Response = "Employed";
+        FormExpressions.IsHidden(employer, FormExpressions.BuildFields(doc)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ComputeValue_DerivesFromOtherFields()
+    {
+        var doc = Doc(
+            new Prompt { Id = "qty", Response = "3" },
+            new Prompt { Id = "price", Response = "4.5" },
+            new Prompt { Id = "total", Hints = new PromptHints { ExprValue = "double(qty) * double(price)" } });
+
+        var total = FormExpressions.GetAllPrompts(doc)[2];
+        FormExpressions.ComputeValue(total, FormExpressions.BuildFields(doc)).Should().Be("13.5");
+        FormExpressions.IsReadOnly(total, FormExpressions.BuildFields(doc)).Should().BeTrue("computed fields are read-only");
+    }
+
+    [Fact]
+    public void RecomputeComputedValues_SettlesChainedTotals()
+    {
+        // grand = sub1 + sub2; sub1 = a + b; sub2 = c  → fixpoint over chained deps.
+        var doc = Doc(
+            new Prompt { Id = "a", Response = "1" },
+            new Prompt { Id = "b", Response = "2" },
+            new Prompt { Id = "c", Response = "10" },
+            new Prompt { Id = "sub1", Hints = new PromptHints { ExprValue = "double(a) + double(b)" } },
+            new Prompt { Id = "sub2", Hints = new PromptHints { ExprValue = "double(c)" } },
+            new Prompt { Id = "grand", Hints = new PromptHints { ExprValue = "double(sub1) + double(sub2)" } });
+
+        var changed = FormExpressions.RecomputeComputedValues(doc);
+
+        changed.Should().BeTrue();
+        var p = FormExpressions.GetAllPrompts(doc);
+        p.Single(x => x.Id == "sub1").Response.Should().Be("3");
+        p.Single(x => x.Id == "sub2").Response.Should().Be("10");
+        p.Single(x => x.Id == "grand").Response.Should().Be("13");
+    }
+
+    [Fact]
+    public void RecomputeComputedValues_CircularReference_TerminatesSafely()
+    {
+        var doc = Doc(
+            new Prompt { Id = "x", Hints = new PromptHints { ExprValue = "double(y) + 1" } },
+            new Prompt { Id = "y", Hints = new PromptHints { ExprValue = "double(x) + 1" } });
+
+        var act = () => FormExpressions.RecomputeComputedValues(doc);
+
+        act.Should().NotThrow("a circular computed reference must terminate, not hang");
+    }
+
+    [Fact]
+    public void IsExpected_IsConditional()
+    {
+        var doc = Doc(
+            new Prompt { Id = "emp_status", Response = "Employed" },
+            new Prompt { Id = "employer", Hints = new PromptHints { ExprExpected = "emp_status == 'Employed'" } });
+        var employer = FormExpressions.GetAllPrompts(doc)[1];
+
+        FormExpressions.IsExpected(employer, FormExpressions.BuildFields(doc)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ReturnsMessageOrNull()
+    {
+        var doc = Doc(
+            new Prompt { Id = "start", Response = "2021-01-01" },
+            new Prompt
+            {
+                Id = "end", Response = "2020-01-01",
+                Hints = new PromptHints { ExprValidation = "_this == '' || start == '' ? '' : (timestamp(_this) > timestamp(start) ? '' : 'End must be after start')" },
+            });
+        var end = FormExpressions.GetAllPrompts(doc)[1];
+
+        FormExpressions.Validate(end, FormExpressions.BuildFields(doc)).Should().Be("End must be after start");
+
+        end.Response = "2022-01-01";
+        FormExpressions.Validate(end, FormExpressions.BuildFields(doc)).Should().BeNull("valid → no message");
+    }
+
+    [Fact]
+    public void BrokenExpression_DegradesGracefully()
+    {
+        var doc = Doc(new Prompt { Id = "p", Hints = new PromptHints { ExprHidden = "this is ) not valid" } });
+        var p = FormExpressions.GetAllPrompts(doc)[0];
+
+        FormExpressions.IsHidden(p, FormExpressions.BuildFields(doc)).Should().BeFalse("a broken hint must not hide/block the field");
+    }
+
+    [Fact]
+    public void ExprHints_RoundTripThroughJson()
+    {
+        var serializer = new AprJsonSerializer();
+        var doc = Doc(new Prompt
+        {
+            Id = "total",
+            Hints = new PromptHints
+            {
+                ExprHidden = "a == 'x'",
+                ExprValue = "double(a) + 1",
+                ExprExpected = "a != ''",
+                ExprValidation = "a == '' ? 'required' : ''",
+                ExprReadOnly = "true",
+            },
+        });
+
+        var restored = serializer.Deserialize(serializer.Serialize(doc));
+        var hints = FormExpressions.GetAllPrompts(restored)[0].Hints;
+
+        hints.ExprHidden.Should().Be("a == 'x'");
+        hints.ExprValue.Should().Be("double(a) + 1");
+        hints.ExprExpected.Should().Be("a != ''");
+        hints.ExprValidation.Should().Be("a == '' ? 'required' : ''");
+        hints.ExprReadOnly.Should().Be("true");
+    }
+}


### PR DESCRIPTION
**Phase 2 of Milestone 2** — builds on the #54 engine. The format + a pure Core service for computed fields and conditional logic; the reactive desktop UI is Phase 3.

- **Format:** `PromptHints` gains `exprHidden`, `exprValue`, `exprExpected`, `exprValidation`, `exprReadOnly` (CEL-subset strings; JSON round-trips).
- **`FormExpressions`** evaluates them against live responses: conditional **visibility** (`IsHidden`), **computed read-only values** (`ComputeValue` + `RecomputeComputedValues` with **fixpoint** recompute so chained totals settle; bounded so circular refs terminate), **conditional-required** (`IsExpected`), and **cross-field validation** (`Validate`).
- All **advisory + graceful**: a broken expression falls back to a safe default (visible / not required / valid / unchanged) and never blocks input.

8 service tests (incl. chained totals, circular safety, validation, graceful degradation, JSON round-trip); Core **471 → 479**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)