### PR TITLE
feat(desktop): cross-field validation in the advisory panel (Milestone 2, Phase 3a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Cross-field validation in the advisory panel** — `exprValidation` results now
+  appear as advisories (clickable to the field), alongside the data-type /
+  hidden-character / mixed-script advisors. Advisory-only, never blocking. First
+  reactive surfacing of the Milestone 2 expression hints; live computed-value /
+  show-hide UI is the next phase.
 - **Expression hints + form evaluation** — `PromptHints` gains `exprHidden`,
   `exprValue`, `exprExpected`, `exprValidation`, `exprReadOnly` (CEL-subset
   strings; round-trip through JSON). `FormExpressions` (Core) evaluates them

--- a/src/PromptResponse.Desktop/ViewModels/MainShellViewModel.cs
+++ b/src/PromptResponse.Desktop/ViewModels/MainShellViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Media;
 using Avalonia.Styling;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using PromptResponse.Core.Expressions;
 using PromptResponse.Core.Models;
 using PromptResponse.Core.Rendering;
 using PromptResponse.Core.Validation;
@@ -454,6 +455,18 @@ public sealed partial class MainShellViewModel : ObservableObject, IDisposable
             {
                 var (promptId, promptLabel) = ResolvePromptFromPath(doc, warning.PropertyPath);
                 _advisories.Add(new AdvisoryItem(promptId, promptLabel, warning.Message));
+            }
+
+            // Cross-field validation (exprValidation) — advisory, never blocking.
+            var fields = FormExpressions.BuildFields(doc);
+            var today = DateTime.UtcNow.ToString("yyyy-MM-dd");
+            foreach (var prompt in FormExpressions.GetAllPrompts(doc))
+            {
+                var message = FormExpressions.Validate(prompt, fields, today);
+                if (message != null)
+                {
+                    _advisories.Add(new AdvisoryItem(prompt.Id, prompt.Label, message));
+                }
             }
         }
         OnPropertyChanged(nameof(AdvisoryCount));

--- a/tests/PromptResponse.Desktop.Tests/ViewModels/MainShellViewModelTests.cs
+++ b/tests/PromptResponse.Desktop.Tests/ViewModels/MainShellViewModelTests.cs
@@ -145,6 +145,46 @@ public class MainShellViewModelTests
     }
 
     [Fact]
+    public void RefreshAdvisories_SurfacesCrossFieldValidationMessages()
+    {
+        var session = new DocumentSessionService();
+        var doc = new AprDocument
+        {
+            Metadata = new Metadata { Title = "T" },
+            Sections = new List<Section>
+            {
+                new()
+                {
+                    Id = "s", Title = "S",
+                    Prompts = new List<Prompt>
+                    {
+                        new() { Id = "start", Label = "Start", Response = "2021-01-01" },
+                        new()
+                        {
+                            Id = "end", Label = "End", Response = "2020-01-01",
+                            Hints = new PromptHints
+                            {
+                                ExprValidation = "_this == '' || start == '' ? '' : (timestamp(_this) > timestamp(start) ? '' : 'End must be after start')",
+                            },
+                        },
+                    },
+                },
+            },
+        };
+        session.Set(doc, null);
+        var shell = CreateShell(session: session);
+
+        shell.RefreshAdvisories();
+
+        shell.Advisories.Should().Contain(a => a.PromptId == "end" && a.Message == "End must be after start");
+
+        // Fix the value → the validation advisory clears.
+        doc.Sections[0].Prompts[1].Response = "2022-01-01";
+        shell.RefreshAdvisories();
+        shell.Advisories.Should().NotContain(a => a.Message == "End must be after start");
+    }
+
+    [Fact]
     public void FocusAdvisory_RaisesFocusPromptRequested_WithThePromptId()
     {
         var shell = CreateShell();


### PR DESCRIPTION
Surfaces `exprValidation` results as advisories (clickable to the field via #39), alongside the existing data-type / hidden-char / mixed-script advisors — advisory-only, never blocking. First reactive use of the Milestone 2 expression hints, leveraging the existing advisory UI. +1 VM test; Desktop **668 → 670**.

Next (Phase 3b): live computed-value updates + conditional show/hide as you type (prompt-VM reactivity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)