### PR TITLE
feat(desktop): live reactive expressions — calc engine + conditional logic end-to-end (Milestone 2, Phase 3b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Live reactive expressions in the fill view** (Milestone 2, Phase 3b) — as the
+  user types, the desktop form now recomputes computed fields (`exprValue`,
+  read-only, fixpoint), shows/hides prompts (`exprHidden`), and toggles read-only
+  (`exprReadOnly`). `PromptViewModelBase` gains `IsVisible`/`IsReadOnly`; the shell
+  re-evaluates on every response change (re-entrancy-guarded) and on load; the
+  prompt container binds visibility/enablement. Cross-field validation already
+  surfaced in the advisory panel. Calculation engine + conditional logic are now
+  end-to-end.
+
 ## [0.4.0] - 2026-06-06
 
 Headline: **Milestone 2 foundations + polish.** A safe, pure-data **expression

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -45,8 +45,8 @@ Cross-reference with ROADMAP.md for detailed descriptions.
 | Data type hints | P1 | ✅ | text, email, date, number, etc. |
 | Expression parser | P1 | ✅ | Safe CEL-subset evaluator in `PromptResponse.Core.Expressions` (no code execution) |
 | Undo/Redo system | P1 | ✅ | Command pattern implemented |
-| Calculation engine | P1 | 🔄 | Computed fields (`exprValue`) with fixpoint recompute — Core done (`FormExpressions`); reactive UI pending |
-| Conditional logic | P2 | 🔄 | `exprHidden`/`exprExpected`/`exprValidation` — Core done (`FormExpressions`); reactive UI pending |
+| Calculation engine | P1 | ✅ | Computed fields (`exprValue`) with fixpoint recompute; live read-only auto-update in the fill view |
+| Conditional logic | P2 | ✅ | `exprHidden` (live show/hide), `exprExpected`, `exprReadOnly`, `exprValidation` (advisory) — end-to-end |
 
 ---
 

--- a/src/PromptResponse.Desktop/ViewModels/MainShellViewModel.cs
+++ b/src/PromptResponse.Desktop/ViewModels/MainShellViewModel.cs
@@ -836,6 +836,10 @@ public sealed partial class MainShellViewModel : ObservableObject, IDisposable
             {
                 promptVm.PropertyChanged += OnPromptResponseChanged;
             }
+
+            // Apply expression hints once up-front so initial visibility,
+            // read-only, and computed values are correct before any edit.
+            ApplyExpressions();
         }
 
         // Templates default to edit mode (the user is authoring); filled forms
@@ -918,11 +922,59 @@ public sealed partial class MainShellViewModel : ObservableObject, IDisposable
     /// Filtered to Response-only updates so other property pulses (DisplayValue,
     /// Show* derived bools) don't trigger redundant validation passes.
     /// </summary>
+    private bool _applyingExpressions;
+
     private void OnPromptResponseChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
         if (e.PropertyName != nameof(PromptViewModelBase.Response)) return;
+        if (_applyingExpressions) return;   // ignore the cascade from ApplyExpressions itself
+        ApplyExpressions();
         Progress.Refresh();
         RefreshAdvisories();
+    }
+
+    /// <summary>
+    /// Evaluates the document's expression hints against the current responses:
+    /// recomputes computed (<c>exprValue</c>) fields, then sets each prompt VM's
+    /// visibility (<c>exprHidden</c>) and read-only (<c>exprValue</c>/<c>exprReadOnly</c>)
+    /// state. Re-entrancy-guarded since recompute writes back into the model.
+    /// </summary>
+    public void ApplyExpressions()
+    {
+        var doc = _session.CurrentDocument;
+        if (doc == null || _applyingExpressions) return;
+
+        _applyingExpressions = true;
+        try
+        {
+            var today = DateTime.UtcNow.ToString("yyyy-MM-dd");
+            FormExpressions.RecomputeComputedValues(doc, today);
+            var fields = FormExpressions.BuildFields(doc);
+
+            var prompts = new Dictionary<string, Prompt>(StringComparer.Ordinal);
+            foreach (var p in FormExpressions.GetAllPrompts(doc))
+            {
+                if (!string.IsNullOrEmpty(p.Id))
+                {
+                    prompts[p.Id] = p;   // last wins on the rare duplicate id
+                }
+            }
+
+            foreach (var vm in _promptViewModels)
+            {
+                if (!prompts.TryGetValue(vm.Id, out var prompt))
+                {
+                    continue;
+                }
+                vm.IsVisible = !FormExpressions.IsHidden(prompt, fields, today);
+                vm.IsReadOnly = FormExpressions.IsReadOnly(prompt, fields, today);
+                vm.RefreshFromModel();   // pick up any recomputed value
+            }
+        }
+        finally
+        {
+            _applyingExpressions = false;
+        }
     }
 
     private void OnDirtyChanged(object? sender, bool isDirty)

--- a/src/PromptResponse.Desktop/ViewModels/Prompts/PromptViewModelBase.cs
+++ b/src/PromptResponse.Desktop/ViewModels/Prompts/PromptViewModelBase.cs
@@ -133,6 +133,58 @@ public abstract class PromptViewModelBase : INotifyPropertyChanged, IDisposable
         }
     }
 
+    private bool _isVisible = true;
+
+    /// <summary>
+    /// Whether this prompt is shown. Driven by the document's <c>exprHidden</c>
+    /// hint (conditional visibility); defaults to visible. The view binds the
+    /// prompt container's visibility to this.
+    /// </summary>
+    public bool IsVisible
+    {
+        get => _isVisible;
+        set
+        {
+            if (_isVisible == value) return;
+            _isVisible = value;
+            Notify(nameof(IsVisible));
+        }
+    }
+
+    private bool _isReadOnly;
+
+    /// <summary>
+    /// Whether this prompt is read-only — true for computed fields (<c>exprValue</c>)
+    /// and when <c>exprReadOnly</c> is truthy. The view binds input editability to
+    /// <see cref="IsInputEnabled"/>.
+    /// </summary>
+    public bool IsReadOnly
+    {
+        get => _isReadOnly;
+        set
+        {
+            if (_isReadOnly == value) return;
+            _isReadOnly = value;
+            Notify(nameof(IsReadOnly));
+            Notify(nameof(IsInputEnabled));
+        }
+    }
+
+    /// <summary>Convenience inverse of <see cref="IsReadOnly"/> for binding input enablement.</summary>
+    public bool IsInputEnabled => !_isReadOnly;
+
+    /// <summary>
+    /// Re-reads the response from the underlying model and pulses the derived
+    /// display properties. Called after expression recompute writes a computed
+    /// value straight to the model (bypassing the VM setter).
+    /// </summary>
+    public void RefreshFromModel()
+    {
+        Notify(nameof(Response));
+        Notify(nameof(DisplayValue));
+        OnDerivedPropertiesShouldRefresh();
+    }
+
     /// <summary>
     /// Profile-aware rendered string for read-only display. Returns the raw response
     /// unchanged on the Default profile and on any non-formatting composition.

--- a/src/PromptResponse.Desktop/Views/SectionView.axaml
+++ b/src/PromptResponse.Desktop/Views/SectionView.axaml
@@ -44,6 +44,15 @@
                         <StackPanel Spacing="16"/>
                     </ItemsPanelTemplate>
                 </ItemsControl.ItemsPanel>
+                <ItemsControl.Styles>
+                    <!-- Conditional visibility (exprHidden) and read-only (exprValue/
+                         exprReadOnly) are driven per-prompt: bind the item container
+                         to the prompt VM's IsVisible / IsInputEnabled. -->
+                    <Style Selector="ContentPresenter">
+                        <Setter Property="IsVisible" Value="{ReflectionBinding IsVisible}"/>
+                        <Setter Property="IsEnabled" Value="{ReflectionBinding IsInputEnabled}"/>
+                    </Style>
+                </ItemsControl.Styles>
             </ItemsControl>
 
             <!-- Recursive nested sections, indented with a left rule. The left-rule

--- a/tests/PromptResponse.Desktop.Tests/ViewModels/MainShellViewModelTests.cs
+++ b/tests/PromptResponse.Desktop.Tests/ViewModels/MainShellViewModelTests.cs
@@ -144,6 +144,63 @@ public class MainShellViewModelTests
         }
     }
 
+    private static AprDocument ExprDoc() => new()
+    {
+        Metadata = new Metadata { Title = "T" },
+        Sections = new List<Section>
+        {
+            new()
+            {
+                Id = "s", Title = "S",
+                Prompts = new List<Prompt>
+                {
+                    new() { Id = "status", Label = "Status", Response = "Employed" },
+                    new() { Id = "employer", Label = "Employer", Hints = new PromptHints { ExprHidden = "status == 'Retired'" } },
+                    new() { Id = "qty", Label = "Qty", Response = "2" },
+                    new() { Id = "price", Label = "Price", Response = "3" },
+                    new() { Id = "total", Label = "Total", Hints = new PromptHints { ExprValue = "double(qty) * double(price)" } },
+                },
+            },
+        },
+    };
+
+    [Fact]
+    public void Expressions_ConditionalVisibility_UpdatesAsDriverChanges()
+    {
+        var session = new DocumentSessionService();
+        var shell = CreateShell(session: session);
+        session.Set(ExprDoc(), null);   // set after the shell subscribes to DocumentChanged
+
+        var status = shell.PromptViewModels.Single(p => p.Id == "status");
+        var employer = shell.PromptViewModels.Single(p => p.Id == "employer");
+
+        employer.IsVisible.Should().BeTrue("status is Employed at load");
+
+        status.Response = "Retired";
+        employer.IsVisible.Should().BeFalse("exprHidden becomes true");
+
+        status.Response = "Employed";
+        employer.IsVisible.Should().BeTrue("driver reverted");
+    }
+
+    [Fact]
+    public void Expressions_ComputedField_IsReadOnly_AndRecomputesLive()
+    {
+        var session = new DocumentSessionService();
+        var shell = CreateShell(session: session);
+        session.Set(ExprDoc(), null);   // set after the shell subscribes to DocumentChanged
+
+        var qty = shell.PromptViewModels.Single(p => p.Id == "qty");
+        var total = shell.PromptViewModels.Single(p => p.Id == "total");
+
+        total.Response.Should().Be("6", "2 * 3 computed at load");
+        total.IsReadOnly.Should().BeTrue("computed fields are read-only");
+        total.IsInputEnabled.Should().BeFalse();
+
+        qty.Response = "5";
+        total.Response.Should().Be("15", "recomputed live when a dependency changes");
+    }
+
     [Fact]
     public void RefreshAdvisories_SurfacesCrossFieldValidationMessages()
     {


### PR DESCRIPTION
**Completes Milestone 2.** Wires `FormExpressions` into the desktop fill view *reactively*. On every response change (and on load), `ApplyExpressions`:
- recomputes computed fields (`exprValue`) — read-only, fixpoint, circular-safe;
- sets each prompt's **visibility** (`exprHidden`) and **read-only** (`exprValue`/`exprReadOnly`).
Re-entrancy-guarded since recompute writes back through the model.

- `PromptViewModelBase`: `IsVisible` / `IsReadOnly` / `IsInputEnabled` + `RefreshFromModel()`.
- `SectionView`: the prompt item container binds visibility + enablement to the prompt VM.

With the validation advisories from Phase 3a, the **calculation engine** and **conditional logic** are now end-to-end (Core logic + reactive UI). +2 VM tests (live show/hide; computed read-only recompute); Desktop **670 → 672**. FEATURES marks both ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)