### PR TITLE
release(v0.4.1): Order Form demo template + Milestone 2 complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-06
+
+Completes **Milestone 2** end-to-end: live reactive expressions in the desktop
+fill view (computed fields auto-update, conditional show/hide, read-only) on top
+of the v0.4.0 engine, plus an **Order Form** starter template demonstrating a
+computed line total and conditional fields.
+
 ### Added
 
+- **Order Form demo template** — a bundled, accessibility-validated starter
+  showing a computed `line_total` (`exprValue`) that updates live, a gift message
+  that appears only for gifts (`exprHidden`), and a rush reason that becomes
+  expected when rush delivery is selected (`exprExpected`). Selectable from the
+  home screen; exercised end-to-end by a test.
 - **Live reactive expressions in the fill view** (Milestone 2, Phase 3b) — as the
   user types, the desktop form now recomputes computed fields (`exprValue`,
   read-only, fixpoint), shows/hides prompts (`exprHidden`), and toggles read-only

--- a/examples/order-form.aprt
+++ b/examples/order-form.aprt
@@ -1,0 +1,118 @@
+{
+  "version": "1.0",
+  "documentType": "template",
+  "metadata": {
+    "title": "Order Form (computed + conditional demo)",
+    "description": "Demonstrates Milestone 2 expression hints: a computed line total that updates live, and fields that appear only when relevant.",
+    "created": "2026-06-06T00:00:00Z",
+    "modified": "2026-06-06T00:00:00Z",
+    "author": "PromptResponse Team",
+    "templateId": "order-form",
+    "templateVersion": "1.0"
+  },
+  "sections": [
+    {
+      "id": "section_order",
+      "title": "Order",
+      "description": "Enter the item, quantity, and unit price — the line total is calculated for you.",
+      "prompts": [
+        {
+          "id": "item",
+          "label": "Item",
+          "response": "",
+          "hints": {
+            "placeholder": "e.g. Widget, size M",
+            "expectedDataType": "text",
+            "helpText": "What you are ordering."
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "quantity",
+          "label": "Quantity",
+          "response": "",
+          "hints": {
+            "placeholder": "1",
+            "expectedDataType": "number",
+            "helpText": "How many units."
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "unit_price",
+          "label": "Unit Price",
+          "response": "",
+          "hints": {
+            "placeholder": "0.00",
+            "expectedDataType": "currency",
+            "helpText": "Price per unit."
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "line_total",
+          "label": "Line Total",
+          "response": "",
+          "hints": {
+            "expectedDataType": "currency",
+            "helpText": "Calculated automatically as quantity x unit price.",
+            "exprValue": "quantity == '' || unit_price == '' ? '' : double(quantity) * double(unit_price)"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    },
+    {
+      "id": "section_delivery",
+      "title": "Delivery",
+      "description": "Some fields appear only when they apply.",
+      "prompts": [
+        {
+          "id": "is_gift",
+          "label": "Is this a gift?",
+          "response": "",
+          "hints": {
+            "expectedDataType": "boolean",
+            "helpText": "Tick if this order is a gift."
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "gift_message",
+          "label": "Gift message",
+          "response": "",
+          "hints": {
+            "placeholder": "Your message to include with the gift",
+            "expectedDataType": "multiline",
+            "helpText": "Shown only when the order is a gift.",
+            "exprHidden": "is_gift != 'true'"
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "rush",
+          "label": "Rush delivery?",
+          "response": "",
+          "hints": {
+            "expectedDataType": "boolean",
+            "helpText": "Tick to request expedited delivery."
+          },
+          "responseMetadata": {}
+        },
+        {
+          "id": "rush_reason",
+          "label": "Reason for rush",
+          "response": "",
+          "hints": {
+            "placeholder": "Why is this order urgent?",
+            "expectedDataType": "text",
+            "helpText": "Shown and expected only when rush delivery is requested.",
+            "exprHidden": "rush != 'true'",
+            "exprExpected": "rush == 'true'"
+          },
+          "responseMetadata": {}
+        }
+      ]
+    }
+  ]
+}

--- a/src/PromptResponse.Cli/PromptResponse.Cli.csproj
+++ b/src/PromptResponse.Cli/PromptResponse.Cli.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <PackageId>PromptResponse.Cli</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.4.1</Version>
     <Authors>PromptResponse Contributors</Authors>
     <Description>Command-line tool for working with APR (Adaptive Prompt Response) files</Description>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>

--- a/src/PromptResponse.Core/PromptResponse.Core.csproj
+++ b/src/PromptResponse.Core/PromptResponse.Core.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <PackageId>PromptResponse.Core</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.4.1</Version>
     <Authors>PromptResponse Contributors</Authors>
     <Description>Core library for APR (Adaptive Prompt Response) form format</Description>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>

--- a/src/PromptResponse.Desktop/PromptResponse.Desktop.csproj
+++ b/src/PromptResponse.Desktop/PromptResponse.Desktop.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>0.4.0</Version>
+    <Version>0.4.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -40,6 +40,7 @@
     <_Starter Include="..\..\examples\contact-intake.aprt" />
     <_Starter Include="..\..\examples\event-registration.aprt" />
     <_Starter Include="..\..\examples\incident-report.aprt" />
+    <_Starter Include="..\..\examples\order-form.aprt" />
     <None Include="@(_Starter)" Link="Templates\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/tests/PromptResponse.AccessibilityTests/AprAccessibilityValidationTests.cs
+++ b/tests/PromptResponse.AccessibilityTests/AprAccessibilityValidationTests.cs
@@ -265,6 +265,7 @@ public class AprAccessibilityValidationTests
     [InlineData("contact-intake.aprt")]
     [InlineData("event-registration.aprt")]
     [InlineData("incident-report.aprt")]
+    [InlineData("order-form.aprt")]
     public async Task StarterTemplate_IsAccessible(string fileName)
     {
         var path = Path.Combine(RepoRoot, "examples", fileName);

--- a/tests/PromptResponse.Core.Tests/Expressions/FormExpressionsTests.cs
+++ b/tests/PromptResponse.Core.Tests/Expressions/FormExpressionsTests.cs
@@ -118,6 +118,32 @@ public class FormExpressionsTests
     }
 
     [Fact]
+    public void DemoTemplate_ComputesTotal_AndHidesConditionalFields()
+    {
+        // The bundled order-form demo must actually behave as advertised.
+        var path = Path.Combine(
+            Directory.GetCurrentDirectory(), "..", "..", "..", "..", "..", "examples", "order-form.aprt");
+        File.Exists(path).Should().BeTrue("the order-form demo template must exist");
+
+        var doc = new AprJsonSerializer().Deserialize(File.ReadAllText(path));
+        var byId = FormExpressions.GetAllPrompts(doc).ToDictionary(p => p.Id);
+
+        byId["quantity"].Response = "3";
+        byId["unit_price"].Response = "4.5";
+        FormExpressions.RecomputeComputedValues(doc);
+        byId["line_total"].Response.Should().Be("13.5", "computed line total = qty x price");
+
+        // Conditional gift message: hidden until is_gift is true.
+        FormExpressions.IsHidden(byId["gift_message"], FormExpressions.BuildFields(doc)).Should().BeTrue();
+        byId["is_gift"].Response = "true";
+        FormExpressions.IsHidden(byId["gift_message"], FormExpressions.BuildFields(doc)).Should().BeFalse();
+
+        // Rush reason becomes expected only when rush is requested.
+        byId["rush"].Response = "true";
+        FormExpressions.IsExpected(byId["rush_reason"], FormExpressions.BuildFields(doc)).Should().BeTrue();
+    }
+
+    [Fact]
     public void ExprHints_RoundTripThroughJson()
     {
         var serializer = new AprJsonSerializer();


### PR DESCRIPTION
Cuts **v0.4.1**, completing Milestone 2 end-to-end. Adds the **Order Form** demo template (computed `line_total`, conditional `gift_message`, conditional-expected `rush_reason`) — bundled in the home-screen gallery, accessibility-validated, and exercised end-to-end. Bumps to 0.4.1 and rolls the Phase 3b reactive UI into the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)