### PR TITLE
feat: HTML export — browser-fill foundation (Milestone 2 wedge, Path B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **HTML export** — `apr export <file> --format=html` renders a self-contained,
+  accessible HTML page (semantic headings, labeled fields, real tables with
+  row/column headers, `lang` attribute, minimal inline CSS). All dynamic text is
+  HTML-encoded (an XSS boundary, since responses are arbitrary input). New
+  dependency-free `HtmlDocumentRenderer` on the shared `IDocumentRenderer` seam —
+  the foundation for a future browser fill/view path (Milestone 2 wedge, Path B).
+
 ## [0.4.1] - 2026-06-06
 
 Completes **Milestone 2** end-to-end: live reactive expressions in the desktop

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -77,6 +77,7 @@ Cross-reference with ROADMAP.md for detailed descriptions.
 | Feature | Priority | Status | Notes |
 |---------|----------|--------|-------|
 | CSV/JSON/TXT export | P1 | ✅ | Via CLI export command |
+| HTML export | P2 | ✅ | Accessible HTML page (`export --format=html`); foundation for a browser fill path |
 | **PDF export** | **P1** | **✅** | Flat **and** fillable-AcroForm PDF via CLI (`export --format=pdf [--fillable]`) and the desktop File → Export menu (pdfe engine); carries document metadata. Unicode text rendering through the builder is the remaining gap (pdfe#398) (#31) |
 | Word export (.docx) | P2 | ⏳ | Export to Word format |
 | Excel export (.xlsx) | P2 | ⏳ | Export to spreadsheet |

--- a/src/PromptResponse.Cli/Commands/ExportCommand.cs
+++ b/src/PromptResponse.Cli/Commands/ExportCommand.cs
@@ -24,12 +24,13 @@ public class ExportCommand : ICommand
         if (args.Length == 0)
         {
             Console.Error.WriteLine("Error: File path required");
-            Console.Error.WriteLine("Usage: apr export <file> [--format=<csv|json|txt|pdf>] [--output=<file>] [--exclude-empty] [--fillable]");
+            Console.Error.WriteLine("Usage: apr export <file> [--format=<csv|json|txt|html|pdf>] [--output=<file>] [--exclude-empty] [--fillable]");
             Console.Error.WriteLine();
             Console.Error.WriteLine("Formats:");
             Console.Error.WriteLine("  csv  - Comma-separated values (default)");
             Console.Error.WriteLine("  json - JSON format with prompt/response pairs");
             Console.Error.WriteLine("  txt  - Plain text format");
+            Console.Error.WriteLine("  html - Accessible HTML page");
             Console.Error.WriteLine("  pdf  - Flattened PDF (requires --output)");
             Console.Error.WriteLine();
             Console.Error.WriteLine("Options:");
@@ -56,10 +57,10 @@ public class ExportCommand : ICommand
             return 1;
         }
 
-        if (!new[] { "csv", "json", "txt", "pdf" }.Contains(format.ToLowerInvariant()))
+        if (!new[] { "csv", "json", "txt", "html", "pdf" }.Contains(format.ToLowerInvariant()))
         {
             Console.Error.WriteLine($"Error: Unsupported format: {format}");
-            Console.Error.WriteLine("Supported formats: csv, json, txt, pdf");
+            Console.Error.WriteLine("Supported formats: csv, json, txt, html, pdf");
             return 1;
         }
 
@@ -81,6 +82,7 @@ public class ExportCommand : ICommand
                 "csv" => ExportToCsv(document),
                 "json" => ExportToJson(document),
                 "txt" => ExportToText(document),
+                "html" => ExportToHtml(document),
                 _ => throw new InvalidOperationException($"Unsupported format: {format}")
             };
 
@@ -247,6 +249,13 @@ public class ExportCommand : ICommand
             var childPath = currentPath == null ? childSection.Title : $"{currentPath} / {childSection.Title}";
             ExtractResponsesFromSection(childSection, rootSectionTitle, childPath, responses);
         }
+    }
+
+    private static string ExportToHtml(AprDocument document)
+    {
+        using var stream = new MemoryStream();
+        new HtmlDocumentRenderer().Render(document, RenderOptions.Default, stream);
+        return Encoding.UTF8.GetString(stream.ToArray());
     }
 
     private string ExportToText(AprDocument document)

--- a/src/PromptResponse.Core/Rendering/HtmlDocumentRenderer.cs
+++ b/src/PromptResponse.Core/Rendering/HtmlDocumentRenderer.cs
@@ -1,0 +1,141 @@
+using System.Net;
+using System.Text;
+using PromptResponse.Core.Models;
+
+namespace PromptResponse.Core.Rendering;
+
+/// <summary>
+/// A dependency-free <see cref="IDocumentRenderer"/> that renders a document to
+/// a self-contained, accessible HTML page. Foundation for a browser fill/view
+/// path; also useful standalone (<c>apr export --format=html</c>).
+/// </summary>
+/// <remarks>
+/// All dynamic text is HTML-encoded (responses are arbitrary user input, so this
+/// is an XSS boundary). Output is semantic: a single <c>&lt;h1&gt;</c> title,
+/// nested headings by section depth, labeled fields, and real tables with
+/// row/column headers, plus a <c>lang</c> attribute and minimal inline CSS for
+/// readability.
+/// </remarks>
+public sealed class HtmlDocumentRenderer : IDocumentRenderer
+{
+    private const string Css =
+        "body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;line-height:1.5;max-width:48rem;margin:2rem auto;padding:0 1rem;color:#1a1a1a}" +
+        "h1{font-weight:600}h2,h3,h4,h5,h6{margin-top:1.5rem}" +
+        ".muted{color:#666}.field{margin:.75rem 0}.label{font-weight:600}" +
+        ".value{white-space:pre-wrap}.help{font-size:.85em;color:#666;margin:.1rem 0 0}" +
+        "table{border-collapse:collapse;width:100%;margin:.75rem 0}" +
+        "th,td{border:1px solid #ccc;padding:.4rem .6rem;text-align:left;vertical-align:top}" +
+        "th{background:#f5f5f5}";
+
+    private readonly IDocumentRenderModelBuilder _builder;
+
+    /// <summary>
+    /// Initializes the renderer, optionally with a custom model builder
+    /// (defaults to <see cref="DocumentRenderModelBuilder"/>).
+    /// </summary>
+    public HtmlDocumentRenderer(IDocumentRenderModelBuilder? builder = null)
+    {
+        _builder = builder ?? new DocumentRenderModelBuilder();
+    }
+
+    /// <inheritdoc />
+    public string FormatId => "html";
+
+    /// <inheritdoc />
+    public string FileExtension => ".html";
+
+    /// <inheritdoc />
+    public void Render(AprDocument document, RenderOptions options, Stream output)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(output);
+
+        var model = _builder.Build(document, options);
+        var html = BuildHtml(model);
+
+        var writer = new StreamWriter(output, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), leaveOpen: true);
+        writer.Write(html);
+        writer.Flush();
+    }
+
+    private static string BuildHtml(RenderModel model)
+    {
+        var title = string.IsNullOrWhiteSpace(model.Title) ? "(untitled)" : model.Title;
+        var sb = new StringBuilder();
+
+        sb.Append("<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n");
+        sb.Append("<meta charset=\"utf-8\">\n");
+        sb.Append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
+        sb.Append("<title>").Append(Enc(title)).Append("</title>\n");
+        sb.Append("<style>").Append(Css).Append("</style>\n");
+        sb.Append("</head>\n<body>\n");
+
+        sb.Append("<h1>").Append(Enc(title)).Append("</h1>\n");
+        if (!string.IsNullOrWhiteSpace(model.Description))
+        {
+            sb.Append("<p class=\"muted\">").Append(Enc(model.Description!)).Append("</p>\n");
+        }
+
+        foreach (var block in model.Blocks)
+        {
+            AppendBlock(sb, block);
+        }
+
+        sb.Append("</body>\n</html>\n");
+        return sb.ToString();
+    }
+
+    private static void AppendBlock(StringBuilder sb, RenderBlock block)
+    {
+        switch (block)
+        {
+            case HeadingBlock h:
+                var tag = "h" + Math.Clamp(h.Level + 1, 2, 6); // document title is h1
+                sb.Append('<').Append(tag).Append('>').Append(Enc(h.Text)).Append("</").Append(tag).Append(">\n");
+                if (!string.IsNullOrWhiteSpace(h.Description))
+                {
+                    sb.Append("<p class=\"muted\">").Append(Enc(h.Description!)).Append("</p>\n");
+                }
+                break;
+
+            case FieldBlock f:
+                sb.Append("<div class=\"field\">");
+                sb.Append("<div class=\"label\">").Append(Enc(f.Label)).Append("</div>");
+                var valueClass = f.HasResponse ? "value" : "value muted";
+                sb.Append("<div class=\"").Append(valueClass).Append("\">").Append(Enc(f.Value)).Append("</div>");
+                if (!string.IsNullOrWhiteSpace(f.HelpText))
+                {
+                    sb.Append("<p class=\"help\">").Append(Enc(f.HelpText!)).Append("</p>");
+                }
+                sb.Append("</div>\n");
+                break;
+
+            case TableBlock t:
+                AppendTable(sb, t);
+                break;
+        }
+    }
+
+    private static void AppendTable(StringBuilder sb, TableBlock table)
+    {
+        sb.Append("<table>\n<thead>\n<tr><th></th>");
+        foreach (var col in table.ColumnHeaders)
+        {
+            sb.Append("<th scope=\"col\">").Append(Enc(col)).Append("</th>");
+        }
+        sb.Append("</tr>\n</thead>\n<tbody>\n");
+        foreach (var row in table.Rows)
+        {
+            sb.Append("<tr><th scope=\"row\">").Append(Enc(row.Label)).Append("</th>");
+            foreach (var cell in row.Cells)
+            {
+                sb.Append("<td>").Append(Enc(cell.Value)).Append("</td>");
+            }
+            sb.Append("</tr>\n");
+        }
+        sb.Append("</tbody>\n</table>\n");
+    }
+
+    private static string Enc(string s) => WebUtility.HtmlEncode(s);
+}

--- a/tests/PromptResponse.Cli.Tests/Commands/ExportCommandTests.cs
+++ b/tests/PromptResponse.Cli.Tests/Commands/ExportCommandTests.cs
@@ -159,6 +159,31 @@ public class ExportCommandTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_HtmlFormat_WritesAccessibleHtml()
+    {
+        var document = CreateTestDocument();
+        var tempFile = Path.GetTempFileName();
+        var outputFile = Path.Combine(Path.GetTempPath(), $"export_{Guid.NewGuid():N}.html");
+
+        try
+        {
+            await File.WriteAllTextAsync(tempFile, _serializer.Serialize(document));
+
+            var exitCode = await _command.ExecuteAsync(new[] { tempFile, "--format=html", $"--output={outputFile}" });
+
+            exitCode.Should().Be(0);
+            var html = await File.ReadAllTextAsync(outputFile);
+            html.Should().StartWith("<!DOCTYPE html>");
+            html.Should().Contain("<html lang=\"en\">");
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+            if (File.Exists(outputFile)) File.Delete(outputFile);
+        }
+    }
+
+    [Fact]
     public async Task ExecuteAsync_WithCsvFormat_ShouldReturnSuccess()
     {
         // Arrange

--- a/tests/PromptResponse.Core.Tests/Rendering/HtmlDocumentRendererTests.cs
+++ b/tests/PromptResponse.Core.Tests/Rendering/HtmlDocumentRendererTests.cs
@@ -1,0 +1,124 @@
+using System.Text;
+using AwesomeAssertions;
+using NSubstitute;
+using PromptResponse.Core.Models;
+using PromptResponse.Core.Rendering;
+using Xunit;
+
+namespace PromptResponse.Core.Tests.Rendering;
+
+/// <summary>
+/// Verifies the HTML renderer: a self-contained, accessible page that escapes
+/// all dynamic text (an XSS boundary, since responses are arbitrary input).
+/// </summary>
+public class HtmlDocumentRendererTests
+{
+    private readonly HtmlDocumentRenderer _renderer = new();
+
+    private static AprDocument SampleDoc() => new()
+    {
+        Metadata = new Metadata { Title = "Contact Form", Description = "Please complete" },
+        Sections =
+        [
+            new Section
+            {
+                Id = "s1", Title = "Personal",
+                Prompts =
+                [
+                    new Prompt { Id = "name", Label = "Full Name", Response = "Ada", Hints = new PromptHints { HelpText = "As on ID" } },
+                    new Prompt { Id = "phone", Label = "Phone", Response = "" },
+                ],
+            },
+        ],
+    };
+
+    private static string Render(HtmlDocumentRenderer r, AprDocument doc, RenderOptions? o = null) =>
+        Encoding.UTF8.GetString(r.RenderToBytes(doc, o));
+
+    [Fact]
+    public void FormatMetadata_IsHtml()
+    {
+        _renderer.FormatId.Should().Be("html");
+        _renderer.FileExtension.Should().Be(".html");
+    }
+
+    [Fact]
+    public void Render_ProducesAccessibleHtmlEnvelope()
+    {
+        var html = Render(_renderer, SampleDoc());
+
+        html.Should().StartWith("<!DOCTYPE html>");
+        html.Should().Contain("<html lang=\"en\">");
+        html.Should().Contain("<meta charset=\"utf-8\">");
+        html.Should().Contain("<title>Contact Form</title>");
+        html.Should().Contain("<h1>Contact Form</h1>");
+        html.Should().Contain("Full Name");
+        html.Should().Contain("Ada");
+        html.Should().Contain("As on ID");
+        html.TrimEnd().Should().EndWith("</html>");
+    }
+
+    [Fact]
+    public void Render_EscapesDynamicText_NoRawScript()
+    {
+        var doc = new AprDocument
+        {
+            Metadata = new Metadata { Title = "T" },
+            Sections = [new Section { Id = "s", Title = "S", Prompts = [
+                new Prompt { Id = "x", Label = "Comment", Response = "<script>alert('xss')</script>" }] }],
+        };
+
+        var html = Render(_renderer, doc);
+
+        html.Should().NotContain("<script>alert", "responses must be HTML-encoded");
+        html.Should().Contain("&lt;script&gt;");
+    }
+
+    [Fact]
+    public void Render_Table_UsesRealTableMarkupWithHeaders()
+    {
+        var doc = new AprDocument
+        {
+            Metadata = new Metadata { Title = "Tax" },
+            Sections = [new Section
+            {
+                Id = "t", Title = "Years",
+                TableLayout = new TableDefinition
+                {
+                    Columns = [new TableColumn { Id = "rev", Label = "Revenue" }],
+                    FixedRows = [new FixedRow { Id = "y2024", Label = "2024" }],
+                },
+                Sections = [new Section { Id = "y2024", Title = "2024", Prompts = [new Prompt { Id = "y2024.rev", Response = "5000" }] }],
+            }],
+        };
+
+        var html = Render(_renderer, doc);
+
+        html.Should().Contain("<table>");
+        html.Should().Contain("<th scope=\"col\">Revenue</th>");
+        html.Should().Contain("<th scope=\"row\">2024</th>");
+        html.Should().Contain("<td>5000</td>");
+    }
+
+    [Fact]
+    public void Render_ExcludeEmptyFields_OmitsBlank()
+    {
+        var html = Render(_renderer, SampleDoc(), new RenderOptions { IncludeEmptyFields = false });
+        html.Should().Contain("Full Name");
+        html.Should().NotContain("Phone");
+    }
+
+    [Fact]
+    public void Render_GoesThroughTheSharedBuilder()
+    {
+        var builder = Substitute.For<IDocumentRenderModelBuilder>();
+        builder.Build(Arg.Any<AprDocument>(), Arg.Any<RenderOptions>())
+            .Returns(new RenderModel("T", null, DocumentType.Template, [new FieldBlock("L", "V", true, null, null)]));
+        var renderer = new HtmlDocumentRenderer(builder);
+
+        var html = Render(renderer, SampleDoc());
+
+        builder.Received(1).Build(Arg.Any<AprDocument>(), Arg.Any<RenderOptions>());
+        html.Should().Contain("L").And.Contain("V");
+    }
+}


### PR DESCRIPTION
First **wedge item** (Path B / web fill foundation). `HtmlDocumentRenderer` (Core, dependency-free) on the `IDocumentRenderer` seam renders a self-contained, **accessible** HTML page — semantic headings, labeled fields, real tables with row/column headers, `lang`, minimal inline CSS. **All dynamic text is HTML-encoded** (XSS boundary). Wired as `apr export --format=html`.

Reuses the shared `RenderModel` (the Python server proved the shape; this brings it into the seam). 6 renderer tests (incl. XSS-escaping + table headers) + 1 CLI test; Core **479 → 486**, CLI **99 → 100**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)