### PR TITLE
feat: fillable HTML — self-contained browser fill path (Milestone 2 wedge, Path B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   HTML-encoded (an XSS boundary, since responses are arbitrary input). New
   dependency-free `HtmlDocumentRenderer` on the shared `IDocumentRenderer` seam —
   the foundation for a future browser fill/view path (Milestone 2 wedge, Path B).
+- **Fillable HTML (browser fill path)** — `apr export <file> --format=html --fillable`
+  produces a self-contained, **interactive** web form: prompts become live inputs
+  (boolean → checkbox, suggested values → dropdown, multiline → textarea, otherwise
+  a typed input), pre-filled from any existing responses, with a **Download filled
+  form** button that writes a valid `.aprf` JSON file — no server, no backend, no
+  toolchain. Open in any browser, fill, download. Accessible (associated labels,
+  `aria-describedby` help); the embedded document is unicode-escaped and all values
+  HTML-encoded (XSS boundary). New `FillableHtmlDocumentRenderer`. *(Desktop
+  File → Export menu entry is the next step.)*
 
 ## [0.4.1] - 2026-06-06
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -78,6 +78,7 @@ Cross-reference with ROADMAP.md for detailed descriptions.
 |---------|----------|--------|-------|
 | CSV/JSON/TXT export | P1 | ✅ | Via CLI export command |
 | HTML export | P2 | ✅ | Accessible HTML page (`export --format=html`); foundation for a browser fill path |
+| Fillable HTML (browser fill) | P1 | ✅ | `export --format=html --fillable` → self-contained interactive web form that downloads `.aprf`; no server (GUI menu entry pending) |
 | **PDF export** | **P1** | **✅** | Flat **and** fillable-AcroForm PDF via CLI (`export --format=pdf [--fillable]`) and the desktop File → Export menu (pdfe engine); carries document metadata. Unicode text rendering through the builder is the remaining gap (pdfe#398) (#31) |
 | Word export (.docx) | P2 | ⏳ | Export to Word format |
 | Excel export (.xlsx) | P2 | ⏳ | Export to spreadsheet |

--- a/src/PromptResponse.Cli/Commands/ExportCommand.cs
+++ b/src/PromptResponse.Cli/Commands/ExportCommand.cs
@@ -30,12 +30,12 @@ public class ExportCommand : ICommand
             Console.Error.WriteLine("  csv  - Comma-separated values (default)");
             Console.Error.WriteLine("  json - JSON format with prompt/response pairs");
             Console.Error.WriteLine("  txt  - Plain text format");
-            Console.Error.WriteLine("  html - Accessible HTML page");
+            Console.Error.WriteLine("  html - Accessible HTML page (--fillable: interactive form that downloads .aprf)");
             Console.Error.WriteLine("  pdf  - Flattened PDF (requires --output)");
             Console.Error.WriteLine();
             Console.Error.WriteLine("Options:");
             Console.Error.WriteLine("  --exclude-empty  Omit unanswered fields (pdf)");
-            Console.Error.WriteLine("  --fillable       Export a fillable PDF form with live fields (pdf)");
+            Console.Error.WriteLine("  --fillable       Export a fillable form with live fields (pdf, html)");
             return 1;
         }
 
@@ -82,7 +82,7 @@ public class ExportCommand : ICommand
                 "csv" => ExportToCsv(document),
                 "json" => ExportToJson(document),
                 "txt" => ExportToText(document),
-                "html" => ExportToHtml(document),
+                "html" => ExportToHtml(document, fillable),
                 _ => throw new InvalidOperationException($"Unsupported format: {format}")
             };
 
@@ -251,10 +251,14 @@ public class ExportCommand : ICommand
         }
     }
 
-    private static string ExportToHtml(AprDocument document)
+    private static string ExportToHtml(AprDocument document, bool fillable)
     {
+        // --fillable yields an interactive form that downloads an .aprf; otherwise a read-only page.
+        IDocumentRenderer renderer = fillable
+            ? new FillableHtmlDocumentRenderer()
+            : new HtmlDocumentRenderer();
         using var stream = new MemoryStream();
-        new HtmlDocumentRenderer().Render(document, RenderOptions.Default, stream);
+        renderer.Render(document, RenderOptions.Default, stream);
         return Encoding.UTF8.GetString(stream.ToArray());
     }
 

--- a/src/PromptResponse.Core/Rendering/FillableHtmlDocumentRenderer.cs
+++ b/src/PromptResponse.Core/Rendering/FillableHtmlDocumentRenderer.cs
@@ -1,0 +1,306 @@
+using System.Net;
+using System.Text;
+using PromptResponse.Core.Models;
+using PromptResponse.Core.Serialization;
+
+namespace PromptResponse.Core.Rendering;
+
+/// <summary>
+/// Renders an <see cref="AprDocument"/> to a <em>fillable</em>, self-contained
+/// HTML page: a real <c>&lt;form&gt;</c> whose prompts become live inputs, with a
+/// "Download filled form" button that writes a valid <c>.aprf</c> JSON file —
+/// no server, no backend, no toolchain. Open it in any browser, fill, download.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the browser fill path the static <see cref="HtmlDocumentRenderer"/>
+/// laid the foundation for. It mirrors <c>FillablePdfDocumentRenderer</c>'s field
+/// mapping (boolean → checkbox, suggested values → dropdown, multiline → textarea,
+/// otherwise a typed text input) over the shared <see cref="RenderModel"/>.
+/// </para>
+/// <para>
+/// The round-trip is data-driven: the original document is embedded verbatim as
+/// JSON, and a small vanilla-JS shim copies each input's value back into that tree
+/// by prompt id, flips <c>documentType</c> to <c>filledForm</c>, and downloads the
+/// result. The embedded JSON is unicode-escaped so it cannot break out of its
+/// <c>&lt;script&gt;</c> container, and every dynamic value is HTML-encoded — the
+/// same XSS boundary the static renderer enforces (responses are arbitrary input).
+/// </para>
+/// <para>
+/// Table sections are rendered read-only for now (their per-cell prompts carry no
+/// id through the render model, so they cannot round-trip yet) — the same scope
+/// boundary the fillable PDF draws.
+/// </para>
+/// </remarks>
+public sealed class FillableHtmlDocumentRenderer : IDocumentRenderer
+{
+    private static readonly HashSet<string> TruthyValues =
+        new(StringComparer.OrdinalIgnoreCase) { "true", "yes", "y", "1", "x", "checked", "on" };
+
+    private const string Css =
+        "body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;line-height:1.5;max-width:48rem;margin:2rem auto;padding:0 1rem;color:#1a1a1a}" +
+        "h1{font-weight:600}h2,h3,h4,h5,h6{margin-top:1.5rem}" +
+        ".muted{color:#666}.field{margin:1rem 0}.field>label{display:block;font-weight:600;margin-bottom:.25rem}" +
+        ".help{font-size:.85em;color:#666;margin:.15rem 0 0}" +
+        "input[type=text],input[type=email],input[type=number],input[type=date],input[type=tel],input[type=url],textarea,select" +
+        "{width:100%;box-sizing:border-box;padding:.4rem .5rem;font:inherit;border:1px solid #aaa;border-radius:4px}" +
+        "input[type=checkbox]{width:auto;margin-right:.4rem}.check>label{font-weight:600}" +
+        "textarea{min-height:4.5rem;resize:vertical}" +
+        "table{border-collapse:collapse;width:100%;margin:.75rem 0}" +
+        "th,td{border:1px solid #ccc;padding:.4rem .6rem;text-align:left;vertical-align:top}th{background:#f5f5f5}" +
+        ".bar{position:sticky;bottom:0;background:#fff;border-top:1px solid #ddd;padding:1rem 0;margin-top:2rem}" +
+        ".bar button{font:inherit;font-weight:600;padding:.55rem 1.1rem;border:0;border-radius:6px;background:#0b5fff;color:#fff;cursor:pointer}" +
+        ".bar button:hover{background:#0848c4}";
+
+    private readonly IDocumentRenderModelBuilder _builder;
+    private readonly IAprSerializer _serializer;
+
+    /// <summary>
+    /// Initializes the renderer, optionally with a custom model builder and
+    /// serializer (defaulting to <see cref="DocumentRenderModelBuilder"/> and
+    /// <see cref="AprJsonSerializer"/>).
+    /// </summary>
+    public FillableHtmlDocumentRenderer(
+        IDocumentRenderModelBuilder? builder = null,
+        IAprSerializer? serializer = null)
+    {
+        _builder = builder ?? new DocumentRenderModelBuilder();
+        _serializer = serializer ?? new AprJsonSerializer();
+    }
+
+    /// <inheritdoc />
+    public string FormatId => "html-form";
+
+    /// <inheritdoc />
+    public string FileExtension => ".html";
+
+    /// <inheritdoc />
+    public void Render(AprDocument document, RenderOptions options, Stream output)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(output);
+
+        // A fillable form must show every prompt as a blank, regardless of the
+        // caller's empty-field preference.
+        var formOptions = new RenderOptions
+        {
+            IncludeEmptyFields = true,
+            EmptyFieldText = options.EmptyFieldText,
+        };
+        var model = _builder.Build(document, formOptions);
+        var embeddedJson = _serializer.Serialize(document);
+        var html = BuildHtml(model, embeddedJson);
+
+        var writer = new StreamWriter(output, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), leaveOpen: true);
+        writer.Write(html);
+        writer.Flush();
+    }
+
+    private static string BuildHtml(RenderModel model, string embeddedJson)
+    {
+        var title = string.IsNullOrWhiteSpace(model.Title) ? "(untitled)" : model.Title;
+        var sb = new StringBuilder();
+
+        sb.Append("<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n");
+        sb.Append("<meta charset=\"utf-8\">\n");
+        sb.Append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
+        sb.Append("<title>").Append(Enc(title)).Append("</title>\n");
+        sb.Append("<style>").Append(Css).Append("</style>\n");
+        sb.Append("</head>\n<body>\n");
+
+        sb.Append("<h1>").Append(Enc(title)).Append("</h1>\n");
+        if (!string.IsNullOrWhiteSpace(model.Description))
+        {
+            sb.Append("<p class=\"muted\">").Append(Enc(model.Description!)).Append("</p>\n");
+        }
+
+        sb.Append("<form id=\"apr-form\" onsubmit=\"return false\">\n");
+        var fieldSeq = 0;
+        foreach (var block in model.Blocks)
+        {
+            AppendBlock(sb, block, ref fieldSeq);
+        }
+        sb.Append("</form>\n");
+
+        sb.Append("<div class=\"bar\"><button type=\"button\" id=\"apr-download\">Download filled form</button></div>\n");
+
+        // The original document, embedded verbatim for the JS round-trip. Unicode-
+        // escaped so no value can break out of the <script> container.
+        sb.Append("<script type=\"application/json\" id=\"apr-document\">")
+          .Append(EncodeForScript(embeddedJson))
+          .Append("</script>\n");
+        sb.Append("<script>\n").Append(DownloadScript).Append("</script>\n");
+
+        sb.Append("</body>\n</html>\n");
+        return sb.ToString();
+    }
+
+    private static void AppendBlock(StringBuilder sb, RenderBlock block, ref int seq)
+    {
+        switch (block)
+        {
+            case HeadingBlock h:
+                var tag = "h" + Math.Clamp(h.Level + 1, 2, 6); // document title is h1
+                sb.Append('<').Append(tag).Append('>').Append(Enc(h.Text)).Append("</").Append(tag).Append(">\n");
+                if (!string.IsNullOrWhiteSpace(h.Description))
+                {
+                    sb.Append("<p class=\"muted\">").Append(Enc(h.Description!)).Append("</p>\n");
+                }
+                break;
+
+            case FieldBlock f:
+                AppendField(sb, f, ++seq);
+                break;
+
+            case TableBlock t:
+                AppendTable(sb, t);
+                break;
+        }
+    }
+
+    private static void AppendField(StringBuilder sb, FieldBlock f, int seq)
+    {
+        // A stable, valid element id; the prompt id is the round-trip key.
+        var elementId = "f" + seq;
+        var promptId = f.Id;
+        var value = f.HasResponse ? f.Value : string.Empty;
+        var dataType = f.ExpectedDataType ?? string.Empty;
+        var help = !string.IsNullOrWhiteSpace(f.HelpText);
+        var helpId = help ? elementId + "-help" : null;
+        var describedBy = help ? " aria-describedby=\"" + helpId + "\"" : string.Empty;
+        var dataAttr = promptId.Length == 0 ? string.Empty : " data-prompt-id=\"" + Enc(promptId) + "\"";
+
+        if (dataType.Equals("boolean", StringComparison.OrdinalIgnoreCase))
+        {
+            var isChecked = f.HasResponse && TruthyValues.Contains(value);
+            sb.Append("<div class=\"field check\">");
+            sb.Append("<input type=\"checkbox\" id=\"").Append(elementId).Append('"').Append(dataAttr)
+              .Append(isChecked ? " checked" : string.Empty).Append(describedBy).Append(">");
+            sb.Append("<label for=\"").Append(elementId).Append("\">").Append(Enc(f.Label)).Append("</label>");
+            AppendHelp(sb, f, helpId);
+            sb.Append("</div>\n");
+            return;
+        }
+
+        sb.Append("<div class=\"field\">");
+        sb.Append("<label for=\"").Append(elementId).Append("\">").Append(Enc(f.Label)).Append("</label>");
+
+        if (f.Choices is { Count: > 0 })
+        {
+            sb.Append("<select id=\"").Append(elementId).Append('"').Append(dataAttr).Append(describedBy).Append(">");
+            sb.Append("<option value=\"\">").Append(f.HasResponse ? string.Empty : "— choose —").Append("</option>");
+            foreach (var choice in f.Choices)
+            {
+                var selected = f.HasResponse && string.Equals(choice, value, StringComparison.Ordinal) ? " selected" : string.Empty;
+                sb.Append("<option value=\"").Append(Enc(choice)).Append('"').Append(selected).Append('>').Append(Enc(choice)).Append("</option>");
+            }
+            sb.Append("</select>");
+        }
+        else if (dataType.Equals("multiline", StringComparison.OrdinalIgnoreCase))
+        {
+            sb.Append("<textarea id=\"").Append(elementId).Append('"').Append(dataAttr).Append(describedBy).Append('>')
+              .Append(Enc(value)).Append("</textarea>");
+        }
+        else
+        {
+            sb.Append("<input type=\"").Append(InputType(dataType)).Append("\" id=\"").Append(elementId).Append('"')
+              .Append(dataAttr).Append(" value=\"").Append(Enc(value)).Append('"').Append(describedBy).Append(">");
+        }
+
+        AppendHelp(sb, f, helpId);
+        sb.Append("</div>\n");
+    }
+
+    private static void AppendHelp(StringBuilder sb, FieldBlock f, string? helpId)
+    {
+        if (helpId is null) return;
+        sb.Append("<p class=\"help\" id=\"").Append(helpId).Append("\">").Append(Enc(f.HelpText!)).Append("</p>");
+    }
+
+    /// <summary>Maps an advisory APR data-type hint to an HTML input type.</summary>
+    private static string InputType(string dataType) => dataType.ToLowerInvariant() switch
+    {
+        "email" => "email",
+        "number" or "integer" or "decimal" or "currency" => "number",
+        "date" => "date",
+        "datetime" => "datetime-local",
+        "time" => "time",
+        "phone" or "tel" => "tel",
+        "url" => "url",
+        _ => "text",
+    };
+
+    private static void AppendTable(StringBuilder sb, TableBlock table)
+    {
+        // Read-only for now (per-cell prompts carry no id through the model).
+        sb.Append("<table>\n<thead>\n<tr><th></th>");
+        foreach (var col in table.ColumnHeaders)
+        {
+            sb.Append("<th scope=\"col\">").Append(Enc(col)).Append("</th>");
+        }
+        sb.Append("</tr>\n</thead>\n<tbody>\n");
+        foreach (var row in table.Rows)
+        {
+            sb.Append("<tr><th scope=\"row\">").Append(Enc(row.Label)).Append("</th>");
+            foreach (var cell in row.Cells)
+            {
+                sb.Append("<td>").Append(Enc(cell.Value)).Append("</td>");
+            }
+            sb.Append("</tr>\n");
+        }
+        sb.Append("</tbody>\n</table>\n");
+    }
+
+    private static string Enc(string s) => WebUtility.HtmlEncode(s);
+
+    /// <summary>
+    /// Escapes the embedded JSON so it cannot terminate its <c>&lt;script&gt;</c>
+    /// container (<c>&lt;/script&gt;</c>, <c>&lt;!--</c>) while staying valid JSON.
+    /// </summary>
+    private static string EncodeForScript(string json) =>
+        json.Replace("<", "\\u003c").Replace(">", "\\u003e").Replace("&", "\\u0026");
+
+    // Vanilla JS, no dependencies: copy inputs back into the embedded document by
+    // prompt id, mark it filled, and download as <title>.aprf.
+    private const string DownloadScript = """
+(function () {
+  var raw = document.getElementById('apr-document').textContent;
+  function collect() {
+    var map = {};
+    document.querySelectorAll('[data-prompt-id]').forEach(function (el) {
+      var id = el.getAttribute('data-prompt-id');
+      map[id] = el.type === 'checkbox' ? (el.checked ? 'true' : 'false') : el.value;
+    });
+    return map;
+  }
+  function apply(section, map, stamp) {
+    (section.prompts || []).forEach(function (p) {
+      if (Object.prototype.hasOwnProperty.call(map, p.id)) {
+        p.response = map[p.id];
+        p.responseMetadata = p.responseMetadata || {};
+        p.responseMetadata.lastModified = stamp;
+      }
+    });
+    (section.sections || []).forEach(function (s) { apply(s, map, stamp); });
+  }
+  document.getElementById('apr-download').addEventListener('click', function () {
+    var doc = JSON.parse(raw);
+    var map = collect();
+    var stamp = new Date().toISOString();
+    (doc.sections || []).forEach(function (s) { apply(s, map, stamp); });
+    doc.documentType = 'filledForm';
+    var name = (doc.metadata && doc.metadata.title ? doc.metadata.title : 'form').replace(/[\\/:*?"<>|]+/g, '_');
+    var blob = new Blob([JSON.stringify(doc, null, 2)], { type: 'application/json' });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement('a');
+    a.href = url;
+    a.download = name + '.aprf';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(function () { URL.revokeObjectURL(url); }, 0);
+  });
+})();
+""";
+}

--- a/tests/PromptResponse.Cli.Tests/Commands/ExportCommandTests.cs
+++ b/tests/PromptResponse.Cli.Tests/Commands/ExportCommandTests.cs
@@ -184,6 +184,33 @@ public class ExportCommandTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_HtmlFillable_WritesInteractiveForm()
+    {
+        var document = CreateTestDocument();
+        var tempFile = Path.GetTempFileName();
+        var outputFile = Path.Combine(Path.GetTempPath(), $"form_{Guid.NewGuid():N}.html");
+
+        try
+        {
+            await File.WriteAllTextAsync(tempFile, _serializer.Serialize(document));
+
+            var exitCode = await _command.ExecuteAsync(new[] { tempFile, "--format=html", "--fillable", $"--output={outputFile}" });
+
+            exitCode.Should().Be(0);
+            var html = await File.ReadAllTextAsync(outputFile);
+            html.Should().Contain("<form id=\"apr-form\"");
+            html.Should().Contain("id=\"apr-download\"");
+            html.Should().Contain("data-prompt-id=\"prompt1\"");
+            html.Should().Contain(".aprf");
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+            if (File.Exists(outputFile)) File.Delete(outputFile);
+        }
+    }
+
+    [Fact]
     public async Task ExecuteAsync_WithCsvFormat_ShouldReturnSuccess()
     {
         // Arrange

--- a/tests/PromptResponse.Core.Tests/Rendering/FillableHtmlDocumentRendererTests.cs
+++ b/tests/PromptResponse.Core.Tests/Rendering/FillableHtmlDocumentRendererTests.cs
@@ -1,0 +1,142 @@
+using System.Text;
+using AwesomeAssertions;
+using NSubstitute;
+using PromptResponse.Core.Models;
+using PromptResponse.Core.Rendering;
+using Xunit;
+
+namespace PromptResponse.Core.Tests.Rendering;
+
+/// <summary>
+/// Verifies the fillable HTML renderer: a self-contained web form with live
+/// inputs, an embedded copy of the document for the round-trip, and a vanilla-JS
+/// download shim. Like the static renderer, all dynamic text is HTML-encoded
+/// (an XSS boundary), and the embedded JSON is unicode-escaped so it cannot
+/// break out of its script container.
+/// </summary>
+public class FillableHtmlDocumentRendererTests
+{
+    private readonly FillableHtmlDocumentRenderer _renderer = new();
+
+    private static AprDocument SampleDoc() => new()
+    {
+        Metadata = new Metadata { Title = "Contact Form", Description = "Please complete" },
+        Sections =
+        [
+            new Section
+            {
+                Id = "s1", Title = "Personal",
+                Prompts =
+                [
+                    new Prompt { Id = "name", Label = "Full Name", Response = "Ada", Hints = new PromptHints { HelpText = "As on ID" } },
+                    new Prompt { Id = "email", Label = "Email", Response = "", Hints = new PromptHints { ExpectedDataType = "email" } },
+                    new Prompt { Id = "subscribe", Label = "Subscribe", Response = "true", Hints = new PromptHints { ExpectedDataType = "boolean" } },
+                    new Prompt { Id = "color", Label = "Color", Response = "Blue", Hints = new PromptHints { SuggestedValues = ["Red", "Blue"] } },
+                    new Prompt { Id = "notes", Label = "Notes", Response = "", Hints = new PromptHints { ExpectedDataType = "multiline" } },
+                ],
+            },
+        ],
+    };
+
+    private static string Render(FillableHtmlDocumentRenderer r, AprDocument doc, RenderOptions? o = null) =>
+        Encoding.UTF8.GetString(r.RenderToBytes(doc, o));
+
+    [Fact]
+    public void FormatMetadata_IsHtmlForm()
+    {
+        _renderer.FormatId.Should().Be("html-form");
+        _renderer.FileExtension.Should().Be(".html");
+    }
+
+    [Fact]
+    public void Render_ProducesFormWithDownloadButtonAndEmbeddedDocument()
+    {
+        var html = Render(_renderer, SampleDoc());
+
+        html.Should().StartWith("<!DOCTYPE html>");
+        html.Should().Contain("<html lang=\"en\">");
+        html.Should().Contain("<form id=\"apr-form\"");
+        html.Should().Contain("id=\"apr-download\"");
+        html.Should().Contain("Download filled form");
+        html.Should().Contain("<script type=\"application/json\" id=\"apr-document\">");
+        html.Should().Contain(".aprf");
+    }
+
+    [Fact]
+    public void Render_MapsFieldsToTypedInputs()
+    {
+        var html = Render(_renderer, SampleDoc());
+
+        // Each prompt is keyed by its stable id for the round-trip.
+        html.Should().Contain("data-prompt-id=\"name\"");
+        html.Should().Contain("type=\"email\"");                 // email data type
+        html.Should().Contain("type=\"checkbox\"");              // boolean -> checkbox
+        html.Should().Contain("<select");                        // suggested values -> dropdown
+        html.Should().Contain("<textarea");                      // multiline -> textarea
+    }
+
+    [Fact]
+    public void Render_PrefillsExistingResponses()
+    {
+        var html = Render(_renderer, SampleDoc());
+
+        html.Should().Contain("value=\"Ada\"");                  // text default
+        html.Should().Contain("checked");                        // boolean "true"
+        html.Should().Contain("<option value=\"Blue\" selected>"); // dropdown selection
+    }
+
+    [Fact]
+    public void Render_AssociatesLabelsAndHelpForAccessibility()
+    {
+        var html = Render(_renderer, SampleDoc());
+
+        // Label points at the input id, and help is wired via aria-describedby.
+        html.Should().MatchRegex("<label for=\"f\\d+\">Full Name</label>");
+        html.Should().Contain("aria-describedby=\"");
+        html.Should().Contain("As on ID");
+    }
+
+    [Fact]
+    public void Render_EscapesResponses_AndEmbeddedJson_NoScriptBreakout()
+    {
+        var doc = new AprDocument
+        {
+            Metadata = new Metadata { Title = "T" },
+            Sections = [new Section { Id = "s", Title = "S", Prompts = [
+                new Prompt { Id = "x", Label = "Comment", Response = "</script><script>alert(1)</script>" }] }],
+        };
+
+        var html = Render(_renderer, doc);
+
+        // The malicious response must not appear as a live script anywhere —
+        // not in the input value, not inside the embedded JSON block.
+        html.Should().NotContain("<script>alert(1)</script>");
+        // The embedded JSON unicode-escapes '<' (System.Text.Json emits <; our
+        // own pass covers anything it leaves raw) so it can't terminate the script.
+        html.ToLowerInvariant().Should().Contain("\\u003c");
+    }
+
+    [Fact]
+    public void Render_AlwaysIncludesEmptyFields_EvenWhenCallerExcludesThem()
+    {
+        // A form needs its blanks regardless of the caller's empty-field preference.
+        var html = Render(_renderer, SampleDoc(), new RenderOptions { IncludeEmptyFields = false });
+
+        html.Should().Contain("data-prompt-id=\"email\"");
+        html.Should().Contain("data-prompt-id=\"notes\"");
+    }
+
+    [Fact]
+    public void Render_GoesThroughTheSharedBuilder()
+    {
+        var builder = Substitute.For<IDocumentRenderModelBuilder>();
+        builder.Build(Arg.Any<AprDocument>(), Arg.Any<RenderOptions>())
+            .Returns(new RenderModel("T", null, DocumentType.Template, [new FieldBlock("L", "V", true, null, null, "fid")]));
+        var renderer = new FillableHtmlDocumentRenderer(builder);
+
+        var html = Render(renderer, SampleDoc());
+
+        builder.Received(1).Build(Arg.Any<AprDocument>(), Arg.Any<RenderOptions>());
+        html.Should().Contain("data-prompt-id=\"fid\"").And.Contain("value=\"V\"");
+    }
+}


### PR DESCRIPTION
The browser fill path the static HTML renderer laid the foundation for. `apr export <file> --format=html --fillable` produces a **self-contained, interactive web form** — no server, no backend, no toolchain. Open in any browser, fill, click **Download filled form**, get a valid `.aprf`.

**How it works**
- Prompts → live inputs: boolean → checkbox, suggested values → dropdown, multiline → textarea, otherwise a typed input (email/number/date/tel/url/…), pre-filled from existing responses.
- Round-trip is data-driven: the original document is embedded verbatim (**unicode-escaped** so it can't break out of its `<script>`); a tiny vanilla-JS shim copies inputs back by prompt id, flips `documentType` → `filledForm`, and downloads.
- **Accessible**: associated `<label for>`, `aria-describedby` help. All dynamic text **HTML-encoded** (XSS boundary).
- Mirrors `FillablePdfDocumentRenderer`'s field mapping over the shared `RenderModel`. Tables read-only for now (per-cell prompts carry no id through the model yet).

`FillableHtmlDocumentRenderer` (FormatId `html-form`). **8** renderer tests + **1** CLI test; Core **486 → 494**, CLI **100 → 101**; end-to-end verified on the order-form demo (embedded JSON parses, 10 live fields).

Next: a Desktop **File → Export** menu entry (needs a generic export-path picker + accessibility tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)