### PR TITLE
feat: desktop File → Export for HTML + fillable web form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   form** button that writes a valid `.aprf` JSON file — no server, no backend, no
   toolchain. Open in any browser, fill, download. Accessible (associated labels,
   `aria-describedby` help); the embedded document is unicode-escaped and all values
-  HTML-encoded (XSS boundary). New `FillableHtmlDocumentRenderer`. *(Desktop
-  File → Export menu entry is the next step.)*
+  HTML-encoded (XSS boundary). New `FillableHtmlDocumentRenderer`.
+- **Desktop HTML export menu** — File → Export now offers **Export as HTML** and
+  **Export as fillable web form** alongside the PDF options (both with screen-reader
+  names and help text), so the browser fill path is reachable without the CLI.
 
 ## [0.4.1] - 2026-06-06
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -68,6 +68,7 @@ Cross-reference with ROADMAP.md for detailed descriptions.
 | Print preview | P2 | ⏳ | WYSIWYG print layout |
 | Recent files list | P2 | ✅ | Recent files on the home screen, persisted (#34) |
 | PDF / fillable export (GUI) | P1 | ✅ | File → Export: flat PDF + fillable AcroForm (#31) |
+| HTML / web-form export (GUI) | P1 | ✅ | File → Export: read-only HTML page + self-contained fillable web form |
 | Starter templates | P1 | ✅ | 6 bundled accessible templates, selectable on home (#36) |
 
 ---
@@ -78,7 +79,7 @@ Cross-reference with ROADMAP.md for detailed descriptions.
 |---------|----------|--------|-------|
 | CSV/JSON/TXT export | P1 | ✅ | Via CLI export command |
 | HTML export | P2 | ✅ | Accessible HTML page (`export --format=html`); foundation for a browser fill path |
-| Fillable HTML (browser fill) | P1 | ✅ | `export --format=html --fillable` → self-contained interactive web form that downloads `.aprf`; no server (GUI menu entry pending) |
+| Fillable HTML (browser fill) | P1 | ✅ | `export --format=html --fillable` → self-contained interactive web form that downloads `.aprf`; no server. CLI + desktop File → Export |
 | **PDF export** | **P1** | **✅** | Flat **and** fillable-AcroForm PDF via CLI (`export --format=pdf [--fillable]`) and the desktop File → Export menu (pdfe engine); carries document metadata. Unicode text rendering through the builder is the remaining gap (pdfe#398) (#31) |
 | Word export (.docx) | P2 | ⏳ | Export to Word format |
 | Excel export (.xlsx) | P2 | ⏳ | Export to spreadsheet |

--- a/src/PromptResponse.Desktop/Services/FileService.cs
+++ b/src/PromptResponse.Desktop/Services/FileService.cs
@@ -151,19 +151,22 @@ public class FileService : IFileService
         return true;
     }
 
-    public async Task<string?> PickPdfExportPathAsync(string suggestedFileName)
+    public Task<string?> PickPdfExportPathAsync(string suggestedFileName) =>
+        PickExportPathAsync(suggestedFileName, "Export PDF", "PDF Document", "pdf");
+
+    public async Task<string?> PickExportPathAsync(string suggestedFileName, string title, string typeLabel, string extension)
     {
         var window = GetMainWindow();
         if (window == null) return null;
 
         var file = await window.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
         {
-            Title = "Export PDF",
-            DefaultExtension = "pdf",
+            Title = title,
+            DefaultExtension = extension,
             SuggestedFileName = suggestedFileName,
             FileTypeChoices = new[]
             {
-                new FilePickerFileType("PDF Document") { Patterns = new[] { "*.pdf" } }
+                new FilePickerFileType(typeLabel) { Patterns = new[] { "*." + extension } }
             }
         });
 

--- a/src/PromptResponse.Desktop/Services/IFileService.cs
+++ b/src/PromptResponse.Desktop/Services/IFileService.cs
@@ -43,6 +43,17 @@ public interface IFileService
     Task<string?> PickPdfExportPathAsync(string suggestedFileName);
 
     /// <summary>
+    /// Shows a save-file dialog for exporting to an arbitrary format and returns
+    /// the chosen path, or null if cancelled. Does not write anything — the caller
+    /// renders to the returned path.
+    /// </summary>
+    /// <param name="suggestedFileName">The default file name (e.g. "My Form.html").</param>
+    /// <param name="title">The dialog title (e.g. "Export web form").</param>
+    /// <param name="typeLabel">The file-type label shown in the picker (e.g. "HTML Page").</param>
+    /// <param name="extension">The default extension without a dot (e.g. "html").</param>
+    Task<string?> PickExportPathAsync(string suggestedFileName, string title, string typeLabel, string extension);
+
+    /// <summary>
     /// Gets the last opened or saved file path.
     /// </summary>
     string? CurrentFilePath { get; }

--- a/src/PromptResponse.Desktop/ViewModels/MainShellViewModel.cs
+++ b/src/PromptResponse.Desktop/ViewModels/MainShellViewModel.cs
@@ -766,6 +766,34 @@ public sealed partial class MainShellViewModel : ObservableObject, IDisposable
         renderer.Render(doc, Core.Rendering.RenderOptions.Default, stream);
     }
 
+    /// <summary>Exports the current document — with its values — to a read-only HTML page.</summary>
+    [RelayCommand(CanExecute = nameof(HasDocument))]
+    public Task ExportHtml() => ExportToHtmlAsync(fillable: false);
+
+    /// <summary>Exports the current document to a self-contained, fillable HTML web form.</summary>
+    [RelayCommand(CanExecute = nameof(HasDocument))]
+    public Task ExportHtmlForm() => ExportToHtmlAsync(fillable: true);
+
+    private async Task ExportToHtmlAsync(bool fillable)
+    {
+        var doc = _session.CurrentDocument;
+        if (doc is null) return;
+
+        var baseName = string.IsNullOrWhiteSpace(doc.Metadata.Title) ? "form" : doc.Metadata.Title;
+        var suggested = MakeSafeFileName(baseName) + (fillable ? "-form.html" : ".html");
+
+        var title = fillable ? "Export web form" : "Export HTML";
+        var path = await _fileService.PickExportPathAsync(suggested, title, "HTML Page", "html");
+        if (string.IsNullOrEmpty(path)) return;
+
+        IDocumentRenderer renderer = fillable
+            ? new FillableHtmlDocumentRenderer()
+            : new HtmlDocumentRenderer();
+
+        await using var stream = File.Create(path);
+        renderer.Render(doc, Core.Rendering.RenderOptions.Default, stream);
+    }
+
     private static string MakeSafeFileName(string name)
     {
         var invalid = Path.GetInvalidFileNameChars();

--- a/src/PromptResponse.Desktop/Views/MainShellView.axaml
+++ b/src/PromptResponse.Desktop/Views/MainShellView.axaml
@@ -65,6 +65,15 @@
                               Command="{Binding ExportPdfFormCommand}"
                               AutomationProperties.Name="Export as fillable PDF form"
                               AutomationProperties.HelpText="Export to an interactive PDF with fillable fields"/>
+                    <Separator/>
+                    <MenuItem Header="Export as _HTML..."
+                              Command="{Binding ExportHtmlCommand}"
+                              AutomationProperties.Name="Export as HTML"
+                              AutomationProperties.HelpText="Export the current form, with its values, to a read-only HTML page"/>
+                    <MenuItem Header="Export as fillable _web form..."
+                              Command="{Binding ExportHtmlFormCommand}"
+                              AutomationProperties.Name="Export as fillable web form"
+                              AutomationProperties.HelpText="Export a self-contained HTML form that fills in the browser and downloads an .aprf file"/>
                 </MenuItem>
                 <Separator/>
                 <MenuItem Header="_Close"

--- a/tests/PromptResponse.Desktop.Tests/ViewModels/MainShellViewModelTests.cs
+++ b/tests/PromptResponse.Desktop.Tests/ViewModels/MainShellViewModelTests.cs
@@ -144,6 +144,73 @@ public class MainShellViewModelTests
         }
     }
 
+    [Fact]
+    public async Task ExportHtml_WritesPageContainingCurrentValues()
+    {
+        var fs = Substitute.For<IFileService>();
+        var outPath = Path.Combine(Path.GetTempPath(), $"vm_export_{Guid.NewGuid():N}.html");
+        fs.PickExportPathAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>()).Returns(outPath);
+
+        var session = new DocumentSessionService();
+        var doc = MakeTemplate();
+        doc.Sections[0].Prompts[0].Response = "Zaphod Beeblebrox";   // a current value
+        session.Set(doc, null);
+        var shell = CreateShell(fs, session: session);
+
+        try
+        {
+            await shell.ExportHtml();
+
+            File.Exists(outPath).Should().BeTrue();
+            var html = await File.ReadAllTextAsync(outPath);
+            html.Should().StartWith("<!DOCTYPE html>");
+            html.Should().Contain("Zaphod Beeblebrox", "the export must capture the form's current values");
+        }
+        finally
+        {
+            if (File.Exists(outPath)) File.Delete(outPath);
+        }
+    }
+
+    [Fact]
+    public async Task ExportHtmlForm_WritesInteractiveForm()
+    {
+        var fs = Substitute.For<IFileService>();
+        var outPath = Path.Combine(Path.GetTempPath(), $"vm_form_{Guid.NewGuid():N}.html");
+        fs.PickExportPathAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>()).Returns(outPath);
+        var session = new DocumentSessionService();
+        session.Set(MakeTemplate(), null);
+        var shell = CreateShell(fs, session: session);
+
+        try
+        {
+            await shell.ExportHtmlForm();
+
+            var html = await File.ReadAllTextAsync(outPath);
+            html.Should().Contain("<form id=\"apr-form\"");
+            html.Should().Contain("id=\"apr-download\"");
+            html.Should().Contain(".aprf");
+        }
+        finally
+        {
+            if (File.Exists(outPath)) File.Delete(outPath);
+        }
+    }
+
+    [Fact]
+    public async Task ExportHtml_WhenCancelled_WritesNothing()
+    {
+        var fs = Substitute.For<IFileService>();
+        fs.PickExportPathAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>()).Returns((string?)null);
+        var session = new DocumentSessionService();
+        session.Set(MakeTemplate(), null);
+        var shell = CreateShell(fs, session: session);
+
+        await shell.ExportHtml();   // should be a no-op, not throw
+
+        await fs.Received(1).PickExportPathAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
     private static AprDocument ExprDoc() => new()
     {
         Metadata = new Metadata { Title = "T" },


### PR DESCRIPTION
Completes the browser-fill wedge by bringing it to the **GUI** (where office workers live), not just the CLI. File → Export now offers **Export as HTML** (read-only page) and **Export as fillable web form** (self-contained interactive form that downloads an `.aprf`), alongside the existing PDF options.

- Generalizes the picker: `IFileService.PickExportPathAsync(name, title, typeLabel, extension)`; `PickPdfExportPathAsync` delegates to it (public surface unchanged, PDF tests intact).
- New `ExportHtml`/`ExportHtmlForm` commands reuse `HtmlDocumentRenderer` / `FillableHtmlDocumentRenderer`.
- Menu items carry `AutomationProperties.Name` + `HelpText` (accessibility gate).

3 VM tests (values captured, interactive form written, cancel = no-op); Desktop **671 → 674**, accessibility **107** green; full build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)