### PR TITLE
feat: document → APR importer skill (PDF/DOCX/ODP/images)

### DIFF
--- a/.claude/skills/document-to-apr/SKILL.md
+++ b/.claude/skills/document-to-apr/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: document-to-apr
+description: >-
+  Convert an existing form into a PromptResponse APR template (.aprt). Use when
+  the user wants to import, recreate, or "turn into a fillable form" a PDF, Word
+  (.docx), OpenDocument (.odt/.odp), or an image (PNG/JPG/GIF/screenshot/scan) of
+  a paper or printed form. Produces a valid .aprt JSON file that opens in the
+  PromptResponse editor and can be exported to a fillable PDF or web form.
+---
+
+# Document → APR
+
+Turn any form — a PDF, a Word/OpenDocument file, or just a **picture of a paper
+form** — into a PromptResponse **APR template** (`.aprt`). APR is a small,
+layout-free JSON format: a document is sections of prompts (questions). The
+editor and the `apr` CLI then render it to a fillable PDF, an interactive web
+form, plain text, etc.
+
+You (the AI agent) are the importer. You read the source however you read any
+file or image, understand the form's structure, and emit a valid `.aprt`. This
+works in any agent that can see the document — Claude Code, Claude in the
+workspace, Gemini CLI, Codex — because the skill is just instructions + the
+format spec; nothing here is tool-specific.
+
+## Why an agent and not a parser
+
+Most real forms are **not** machine-readable: a PDF is usually flat printed text
+(no form fields), a scan or photo is pixels, a Word form's fields are buried in
+XML. A mechanical parser fails on all of these. You can *look at the form* the
+way a person does — read the labels, see the checkboxes, group the sections — and
+reconstruct it faithfully. That is the whole point of doing this as a skill.
+
+## Procedure
+
+1. **Take in the source.** Open/look at the file the user pointed you to (PDF,
+   .docx, .odt/.odp, or an image). If it's an image or a flat PDF, read it
+   visually. If it's a zipped Office/OpenDocument file and you can't open it
+   directly, unzip it and read `word/document.xml` (DOCX) or `content.xml`
+   (ODT/ODP) as text — but you usually don't need to: read what the form *says*.
+
+2. **Identify the structure**, top to bottom:
+   - **Sections** — visual groupings, headed areas, "Part I / Part II", boxes.
+     Every field belongs to a section. If the form has no groupings, make one
+     section like "Form".
+   - **Fields (prompts)** — each blank, checkbox, line, or labelled space a
+     person fills in. Capture its **label** (the visible question text), and:
+     - the expected **data type** (see the vocabulary below),
+     - any **help text** / instructions printed near it,
+     - a **placeholder** example if one is shown,
+     - **choices** if it's "check one of …" / a list of options,
+     - whether it looks **required** (asterisk, "required", bold "must").
+   - **Tables / grids** — a repeating row/column area (see "Tables" below).
+
+3. **Map to APR.** Build the JSON per `reference/apr-format.md`. Follow every
+   rule in "Hard rules" below or the file won't validate.
+
+4. **Write the file** as `<sensible-name>.aprt` (kebab-case). It's a template, so
+   every `response` is `""`.
+
+5. **Validate.** Run the CLI from the repo root:
+   ```bash
+   dotnet run --project src/PromptResponse.Cli -- validate <file>.aprt
+   ```
+   (or `apr validate <file>.aprt` if the `apr` tool is installed). Fix any
+   reported errors and re-validate until it passes.
+
+6. **Hand off.** Tell the user the file is ready, summarise what you captured
+   (sections / field count / any tables), and note anything you were unsure about
+   (ambiguous labels, unreadable areas) so they can correct it. Mention they can
+   open it in the editor or export it: `apr export <file>.aprt --format=html
+   --fillable` (web form) or `--format=pdf --fillable` (PDF form).
+
+## Hard rules (these make or break validation)
+
+- `version` is `"1.0"`; `documentType` is `"template"`.
+- `metadata.title` is **required** and non-empty.
+- At least one section; **every section needs a non-empty `title`** and a unique
+  non-empty `id`.
+- **Every prompt needs a non-empty `label`** and a unique non-empty `id`.
+- **All ids are unique across the whole document.** Use stable, descriptive,
+  kebab/snake ids (e.g. `applicant-name`, not `q1`).
+- **Every `response` is a string** — always `""` in a template. There are no
+  typed values; a number field still stores `""`.
+- Type hints are **advisory only** — they guide the UI, they never restrict input.
+- **No layout.** Do not invent fonts, colours, positions, page numbers. APR is
+  content only.
+- **Accessibility is required, not optional:** give every prompt a real, unique,
+  human label (never a placeholder as the only label, never duplicate labels);
+  give every section a title; add `helpText` whenever the form prints guidance.
+
+## Data-type hint vocabulary
+
+Set `hints.expectedDataType` to the closest of: `text`, `multiline`, `email`,
+`phone`, `url`, `number`, `currency`, `date`, `time`, `datetime`, `boolean`.
+- Checkbox / yes-no → `boolean`.
+- A field offering a fixed set of options → keep the type (often `text`) and add
+  `hints.suggestedValues: ["…","…"]` (this becomes a dropdown).
+- A large free-text area → `multiline`.
+
+## Tables
+
+If the form has a grid where columns are fields and rows repeat (e.g. "Income by
+year", line items, a schedule), model it as a **table section** — see the table
+example in `reference/examples.md`. Key points:
+- The section carries a `tableLayout` (`columns`, plus either `fixedRows` for a
+  known set of rows, or `dynamicRows` for user-added rows).
+- For **fixed** rows, also create one child section per row whose prompts are the
+  cells, with ids `"{rowId}.{columnId}"`. These cells become individually
+  fillable in the PDF/web exports.
+- For **dynamic** rows (unbounded line items), define `dynamicRows` and no child
+  sections.
+
+## Computed & conditional fields (optional, advanced)
+
+If the form has obvious math ("Total = sum of lines") or conditional fields
+("if yes, explain"), you may add expression hints — but only when confident:
+- `exprValue` — a computed value (read-only), e.g. `double(qty) * double(price)`.
+- `exprHidden` — hide unless truthy, e.g. `is_gift != 'true'`.
+- `exprExpected` — mark required when truthy.
+These reference other prompts by id. **Any id used in an expression must be
+identifier-safe — letters, digits, underscores only, no hyphens** (`unit_price`,
+not `unit-price`, which parses as subtraction). See the expression example in
+`reference/examples.md`. When unsure, leave them out — a plain field is always
+correct.
+
+## References
+
+- `reference/apr-format.md` — the complete, self-contained format spec (the
+  ground truth; read it before emitting JSON).
+- `reference/examples.md` — worked input → output examples (simple form, a table,
+  a computed/conditional field).
+
+When this skill lives in the PromptResponse repo, `docs/FILE_FORMAT.md` and the
+`examples/*.aprt` files are additional ground truth. When you've copied this
+skill into another agent, the two `reference/` files are self-sufficient.

--- a/.claude/skills/document-to-apr/reference/apr-format.md
+++ b/.claude/skills/document-to-apr/reference/apr-format.md
@@ -1,0 +1,166 @@
+# APR format — condensed spec
+
+APR (`.aprt` for templates, `.aprf` for filled forms, `.apr` generic) is UTF-8
+JSON. A document is a tree: **Document → Sections → (nested Sections) → Prompts**.
+It carries content only — no layout, no styling, no code.
+
+## Top level
+
+```json
+{
+  "version": "1.0",
+  "documentType": "template",
+  "metadata": { ... },
+  "sections": [ ... ]
+}
+```
+
+- `version` — always `"1.0"`.
+- `documentType` — `"template"` (blank form) or `"filledForm"` (has answers). When
+  importing, always `"template"`.
+- `metadata` — see below.
+- `sections` — at least one; order is preserved.
+
+## metadata
+
+```json
+{
+  "title": "New Contact Intake",
+  "description": "Collect information from new contacts",
+  "created": "2026-06-06T00:00:00Z",
+  "modified": "2026-06-06T00:00:00Z",
+  "author": "…",
+  "templateId": "contact-intake",
+  "templateVersion": "1.0"
+}
+```
+
+- `title` is **required** and non-empty. Everything else is optional.
+- `templateId` — a stable kebab-case id for the template (recommended).
+- Dates are ISO-8601 UTC strings.
+
+## Section
+
+```json
+{
+  "id": "section_basic_info",
+  "title": "Basic Information",
+  "description": "Personal and contact details",
+  "prompts": [ ... ],
+  "sections": [ ... ]
+}
+```
+
+- `id` — **required**, unique across the whole document.
+- `title` — **required**, non-empty.
+- `description` — optional.
+- `prompts` — the fields directly in this section (may be empty if it only nests
+  sub-sections).
+- `sections` — nested sub-sections, unlimited depth.
+- A section must contain at least one prompt **or** one child section (exception:
+  a table section using `dynamicRows`, which may legitimately start empty).
+- `tableLayout` — present only on table sections (see "Table section").
+
+## Prompt (a field)
+
+```json
+{
+  "id": "prompt_email",
+  "label": "Email Address",
+  "response": "",
+  "hints": {
+    "placeholder": "john.smith@example.com",
+    "expectedDataType": "email",
+    "helpText": "Primary email address",
+    "suggestedValues": ["A", "B"],
+    "validationPattern": "…optional regex (advisory)…"
+  },
+  "responseMetadata": {}
+}
+```
+
+- `id` — **required**, unique across the document.
+- `label` — **required**, non-empty, human-readable, unique (don't reuse labels).
+- `response` — **always a string**; `""` in a template. Even numbers/dates are
+  strings (`"42"`, `"2026-06-06"`).
+- `hints` — all optional, all advisory:
+  - `expectedDataType` — one of `text`, `multiline`, `email`, `phone`, `url`,
+    `number`, `currency`, `date`, `time`, `datetime`, `boolean`.
+  - `placeholder` — example text shown in an empty field.
+  - `helpText` — guidance shown with the field.
+  - `suggestedValues` — array of options → rendered as a dropdown.
+  - `validationPattern` — optional regex; advisory only, never enforced.
+  - Expression hints (advanced): `exprValue`, `exprHidden`, `exprExpected`,
+    `exprReadOnly`, `exprValidation` — see "Expressions".
+- `responseMetadata` — leave as `{}` for a template.
+
+## Table section
+
+A section becomes a table when it has a `tableLayout`. Columns are fields; rows
+repeat.
+
+```json
+{
+  "id": "tbl_income",
+  "title": "Income by Tax Year",
+  "tableLayout": {
+    "columns": [
+      { "id": "wages",    "label": "Wages",    "type": "currency", "placeholder": "0.00" },
+      { "id": "interest", "label": "Interest", "type": "currency" }
+    ],
+    "fixedRows": [
+      { "id": "year_2024", "label": "2024" },
+      { "id": "year_2023", "label": "2023" }
+    ]
+  },
+  "sections": [
+    {
+      "id": "year_2024",
+      "title": "2024",
+      "prompts": [
+        { "id": "year_2024.wages",    "label": "Wages",    "response": "", "hints": { "expectedDataType": "currency" } },
+        { "id": "year_2024.interest", "label": "Interest", "response": "", "hints": { "expectedDataType": "currency" } }
+      ]
+    }
+    // …one child section per fixed row…
+  ]
+}
+```
+
+- `tableLayout.columns[]` — `{ id, label, type?, placeholder?, suggestedValues?, helpText? }`.
+  `type` uses the same vocabulary as `expectedDataType` (`text`, `currency`,
+  `number`, `date`, `boolean`, …).
+- Use **either** `fixedRows` **or** `dynamicRows`:
+  - `fixedRows[]` — `{ id, label }`. For each fixed row, add a **child section**
+    whose `id` equals the row id and whose prompts are the cells. Each cell prompt
+    id is `"{rowId}.{columnId}"`. These cells become individually fillable.
+  - `dynamicRows` — `{ minRows?, maxRows?, rowLabel? }` for user-added rows; do
+    not create child sections.
+
+## Expressions (advanced, optional)
+
+Expression hints use a safe CEL-style subset (no code execution). They reference
+other prompts by **id**. Strings are the value type, so compare with `''` and
+convert with `double(...)` / `int(...)` as needed.
+
+- `exprValue` — computed, read-only value: `double(quantity) * double(unit_price)`.
+- `exprHidden` — hide the prompt when truthy: `is_gift != 'true'`.
+- `exprExpected` — mark required when truthy: `rush == 'true'`.
+- `exprReadOnly` — make read-only when truthy.
+- `exprValidation` — advisory cross-field check.
+
+Only add these when the form clearly implies them. A plain field is always valid.
+
+**Ids used in expressions must be identifier-safe** — letters, digits, and
+underscores only (no hyphens). `unit_price` is fine; `unit-price` parses as
+`unit` minus `price`. Ids not referenced by any expression may use hyphens.
+
+## Validation checklist (what the validator enforces)
+
+- `version == "1.0"`, `metadata.title` non-empty, ≥ 1 section.
+- Every section: non-empty `id` (unique) and non-empty `title`; not empty (has a
+  prompt or child section, unless it's a `dynamicRows` table).
+- Every prompt: non-empty `id` (unique) and non-empty `label`.
+- All ids unique across the entire document.
+- Hints are advisory — they never cause validation failure. (Type mismatches at
+  most produce warnings, never errors.)

--- a/.claude/skills/document-to-apr/reference/examples.md
+++ b/.claude/skills/document-to-apr/reference/examples.md
@@ -1,0 +1,199 @@
+# Worked examples: source form → APR
+
+Three patterns. Each shows the kind of source you'd see and the `.aprt` to emit.
+
+---
+
+## 1. A simple form
+
+**Source (what the form shows):**
+
+> **Volunteer Sign-Up**
+> Help us staff the community fair.
+>
+> *Your details*
+> - Full name: ____________________
+> - Email: ____________________  (we'll send a confirmation)
+> - T-shirt size:  ☐ S  ☐ M  ☐ L  ☐ XL
+>
+> *Availability*
+> - Which day can you help?  ☐ Saturday  ☐ Sunday
+> - Notes / anything we should know: __________________________
+
+**APR (`volunteer-sign-up.aprt`):**
+
+```json
+{
+  "version": "1.0",
+  "documentType": "template",
+  "metadata": {
+    "title": "Volunteer Sign-Up",
+    "description": "Help us staff the community fair.",
+    "templateId": "volunteer-sign-up",
+    "templateVersion": "1.0"
+  },
+  "sections": [
+    {
+      "id": "your-details",
+      "title": "Your details",
+      "prompts": [
+        {
+          "id": "full-name",
+          "label": "Full name",
+          "response": "",
+          "hints": { "expectedDataType": "text" }
+        },
+        {
+          "id": "email",
+          "label": "Email",
+          "response": "",
+          "hints": { "expectedDataType": "email", "helpText": "We'll send a confirmation." }
+        },
+        {
+          "id": "tshirt-size",
+          "label": "T-shirt size",
+          "response": "",
+          "hints": { "expectedDataType": "text", "suggestedValues": ["S", "M", "L", "XL"] }
+        }
+      ]
+    },
+    {
+      "id": "availability",
+      "title": "Availability",
+      "prompts": [
+        {
+          "id": "day",
+          "label": "Which day can you help?",
+          "response": "",
+          "hints": { "expectedDataType": "text", "suggestedValues": ["Saturday", "Sunday"] }
+        },
+        {
+          "id": "notes",
+          "label": "Notes / anything we should know",
+          "response": "",
+          "hints": { "expectedDataType": "multiline" }
+        }
+      ]
+    }
+  ]
+}
+```
+
+Notes:
+- The two visual groups became two sections, each with a `title`.
+- "T-shirt size" and "day" are option lists → `suggestedValues` (a dropdown), not
+  several boolean fields, because the user picks one.
+- The printed "(we'll send a confirmation)" became `helpText`.
+- Every `response` is `""`; every id is unique and descriptive.
+
+---
+
+## 2. A table / grid
+
+**Source:** a grid titled "Quarterly figures" with columns *Revenue*, *Expenses*
+and rows *Q1…Q4*.
+
+**APR (table section):**
+
+```json
+{
+  "id": "quarterly",
+  "title": "Quarterly figures",
+  "tableLayout": {
+    "columns": [
+      { "id": "revenue",  "label": "Revenue",  "type": "currency" },
+      { "id": "expenses", "label": "Expenses", "type": "currency" }
+    ],
+    "fixedRows": [
+      { "id": "q1", "label": "Q1" },
+      { "id": "q2", "label": "Q2" },
+      { "id": "q3", "label": "Q3" },
+      { "id": "q4", "label": "Q4" }
+    ]
+  },
+  "sections": [
+    {
+      "id": "q1",
+      "title": "Q1",
+      "prompts": [
+        { "id": "q1.revenue",  "label": "Revenue",  "response": "", "hints": { "expectedDataType": "currency" } },
+        { "id": "q1.expenses", "label": "Expenses", "response": "", "hints": { "expectedDataType": "currency" } }
+      ]
+    }
+    // …repeat a child section for q2, q3, q4 (ids q2.revenue, q2.expenses, …)…
+  ]
+}
+```
+
+If instead the form lets the user add as many rows as they like (line items,
+expenses), drop `fixedRows` and the child sections, and use:
+
+```json
+"tableLayout": {
+  "columns": [
+    { "id": "item",  "label": "Item",  "type": "text" },
+    { "id": "qty",   "label": "Qty",   "type": "number" },
+    { "id": "price", "label": "Price", "type": "currency" }
+  ],
+  "dynamicRows": { "minRows": 1, "maxRows": 50, "rowLabel": "Item" }
+}
+```
+
+---
+
+## 3. Computed & conditional fields
+
+**Source:** an order line that shows "Line total = Qty × Unit price", and a "Gift
+message" box marked "only if this is a gift".
+
+**APR (prompts within a section):**
+
+> **Important:** any prompt referenced in an expression must have an
+> **identifier-safe id** — letters, digits, and underscores only, no hyphens.
+> `unit_price` works; `unit-price` would be read as `unit` minus `price`. (Ids
+> *not* used in expressions may use hyphens freely, as in examples 1 and 2.)
+
+```json
+{
+  "id": "is_gift",
+  "label": "Is this a gift?",
+  "response": "",
+  "hints": { "expectedDataType": "boolean" }
+},
+{
+  "id": "gift_message",
+  "label": "Gift message",
+  "response": "",
+  "hints": {
+    "expectedDataType": "multiline",
+    "helpText": "Shown only when the order is a gift.",
+    "exprHidden": "is_gift != 'true'"
+  }
+},
+{
+  "id": "quantity",
+  "label": "Quantity",
+  "response": "",
+  "hints": { "expectedDataType": "number" }
+},
+{
+  "id": "unit_price",
+  "label": "Unit price",
+  "response": "",
+  "hints": { "expectedDataType": "currency" }
+},
+{
+  "id": "line_total",
+  "label": "Line total",
+  "response": "",
+  "hints": {
+    "expectedDataType": "currency",
+    "helpText": "Calculated automatically.",
+    "exprValue": "quantity == '' || unit_price == '' ? '' : double(quantity) * double(unit_price)"
+  }
+}
+```
+
+Expressions reference other prompts by id; values are strings, so guard with
+`== ''` and convert with `double(...)`. Omit expressions when the form doesn't
+clearly call for them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Document → APR skill** (`.claude/skills/document-to-apr/`) — a portable AI
+  skill that turns an existing form into an APR template: point any capable agent
+  (Claude Code/workspace, Gemini CLI, Codex) at a PDF, Word (`.docx`),
+  OpenDocument (`.odt`/`.odp`), or even an **image/scan** of a paper form, and it
+  emits a valid `.aprt`. Chosen over a mechanical parser because most real forms
+  aren't machine-readable (flat PDFs, scans, photos) — an agent reads them the way
+  a person does. Includes a self-contained format spec, worked examples, and a
+  `apr validate` verification step.
+
 - **Fillable table cells** — fixed-row table cells are now interactive in both
   fillable outputs: in the **HTML** web form each cell becomes a checkbox
   (boolean column), dropdown (suggested values), or typed input keyed by its

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -109,6 +109,15 @@ Cross-reference with ROADMAP.md for detailed descriptions.
 
 ---
 
+## Import Features
+
+| Feature | Priority | Status | Notes |
+|---------|----------|--------|-------|
+| Document → APR (AI skill) | P1 | ✅ | Portable skill (`.claude/skills/document-to-apr/`): an agent turns a PDF / Word / OpenDocument / **image** of a form into a valid `.aprt`. Works in Claude Code, Gemini CLI, Codex, etc. |
+| AcroForm PDF importer (code) | P3 | ⏳ | Possible deterministic complement for true fillable-PDF/DOCX form fields; deferred — the skill covers the common (flat/scanned) cases |
+
+---
+
 ## CLI Tool Features
 
 | Feature | Priority | Status | Notes |


### PR DESCRIPTION
Import, the way the user steered it: instead of a mechanical parser, a **portable AI skill** that turns an existing form into a valid `.aprt`. Point any capable agent (Claude Code/workspace, Gemini CLI, Codex) at a **PDF, Word (.docx), OpenDocument (.odt/.odp), or an image/scan** of a paper form and it reconstructs the sections, fields, types, choices, and tables into APR.

**Why a skill, not a parser:** most real forms aren't machine-readable — flat printed PDFs, scans, photos. An agent *reads the form like a person does*; AcroForm/XML extraction can't touch those cases.

**Self-contained** (`.claude/skills/document-to-apr/`): `SKILL.md` (procedure + hard rules + type vocabulary + table/expression guidance) and two `reference/` files — a condensed-but-complete format spec and worked examples (simple form, table, computed/conditional). Auto-discovered by Claude Code; portable by copying for other agents.

**Verified:** both example outputs were built and run through `apr validate` (✓ passed) and exported to fillable forms. Caught and documented a real footgun — ids used in expressions must be identifier-safe (no hyphens, or they parse as subtraction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)