### PR TITLE
feat: desktop File → Import from PDF…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Desktop File → Import from PDF…** — imports a fillable PDF into a new
+  untitled template via a file picker (parallel to the Export menu); flat/scanned
+  PDFs show a dialog pointing to the `document-to-apr` skill. Reachable without
+  the CLI.
 - **PDF AcroForm importer** — `apr import <file.pdf> [--output=<f.aprt>] [--title=…]`
   turns a *fillable* PDF into an APR template by reading its form fields (new
   `PdfFormImporter` in `Rendering.Pdf`, via pdfe). Field kinds map to data-type

--- a/src/PromptResponse.Desktop/Services/FileService.cs
+++ b/src/PromptResponse.Desktop/Services/FileService.cs
@@ -154,6 +154,25 @@ public class FileService : IFileService
     public Task<string?> PickPdfExportPathAsync(string suggestedFileName) =>
         PickExportPathAsync(suggestedFileName, "Export PDF", "PDF Document", "pdf");
 
+    public async Task<string?> PickPdfImportPathAsync()
+    {
+        var window = GetMainWindow();
+        if (window == null) return null;
+
+        var files = await window.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Import from PDF",
+            AllowMultiple = false,
+            FileTypeFilter = new[]
+            {
+                new FilePickerFileType("PDF Document") { Patterns = new[] { "*.pdf" } },
+                new FilePickerFileType("All Files") { Patterns = new[] { "*" } }
+            }
+        });
+
+        return files.Count == 0 ? null : files[0].Path.LocalPath;
+    }
+
     public async Task<string?> PickExportPathAsync(string suggestedFileName, string title, string typeLabel, string extension)
     {
         var window = GetMainWindow();

--- a/src/PromptResponse.Desktop/Services/IFileService.cs
+++ b/src/PromptResponse.Desktop/Services/IFileService.cs
@@ -54,6 +54,12 @@ public interface IFileService
     Task<string?> PickExportPathAsync(string suggestedFileName, string title, string typeLabel, string extension);
 
     /// <summary>
+    /// Shows an open-file dialog filtered to PDFs and returns the chosen path, or
+    /// null if cancelled. Does not read the file — the caller imports it.
+    /// </summary>
+    Task<string?> PickPdfImportPathAsync();
+
+    /// <summary>
     /// Gets the last opened or saved file path.
     /// </summary>
     string? CurrentFilePath { get; }

--- a/src/PromptResponse.Desktop/ViewModels/MainShellViewModel.cs
+++ b/src/PromptResponse.Desktop/ViewModels/MainShellViewModel.cs
@@ -739,6 +739,31 @@ public sealed partial class MainShellViewModel : ObservableObject, IDisposable
         AddToRecent(_fileService.CurrentFilePath, _session.CurrentDocument?.Metadata.Title);
     }
 
+    /// <summary>
+    /// Imports a fillable PDF (AcroForm) into a new untitled template and opens it.
+    /// The result is marked dirty so the user is prompted to Save As.
+    /// </summary>
+    [RelayCommand]
+    public async Task ImportPdf()
+    {
+        var path = await _fileService.PickPdfImportPathAsync();
+        if (string.IsNullOrEmpty(path)) return;
+
+        try
+        {
+            var doc = new PdfFormImporter().Import(path);
+            _session.Set(doc, filePath: null, dirty: true);
+        }
+        catch (PdfFormImporter.NoFormFieldsException ex)
+        {
+            await _dialogService.ShowConfirmationAsync("Nothing to import", ex.Message);
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowConfirmationAsync("Import failed", $"Could not import the PDF: {ex.Message}");
+        }
+    }
+
     /// <summary>Exports the currently open document — with its current values — to a flat PDF.</summary>
     [RelayCommand(CanExecute = nameof(HasDocument))]
     public Task ExportPdf() => ExportToPdfAsync(fillable: false);

--- a/src/PromptResponse.Desktop/Views/MainShellView.axaml
+++ b/src/PromptResponse.Desktop/Views/MainShellView.axaml
@@ -43,6 +43,10 @@
                           InputGesture="Ctrl+O"
                           AutomationProperties.Name="Open file"
                           AutomationProperties.HelpText="Open an existing APR template or filled form (Ctrl+O)"/>
+                <MenuItem Header="_Import from PDF..."
+                          Command="{Binding ImportPdfCommand}"
+                          AutomationProperties.Name="Import from PDF"
+                          AutomationProperties.HelpText="Create a template from a fillable PDF's form fields"/>
                 <Separator/>
                 <MenuItem Header="_Save"
                           Command="{Binding SaveCommand}"

--- a/tests/PromptResponse.Desktop.Tests/ViewModels/MainShellViewModelTests.cs
+++ b/tests/PromptResponse.Desktop.Tests/ViewModels/MainShellViewModelTests.cs
@@ -1,7 +1,9 @@
 using AwesomeAssertions;
 using NSubstitute;
 using PromptResponse.Core.Models;
+using PromptResponse.Core.Rendering;
 using PromptResponse.Core.Serialization;
+using PromptResponse.Rendering.Pdf;
 using PromptResponse.Desktop.Profiles;
 using PromptResponse.Desktop.Services;
 using PromptResponse.Desktop.ViewModels;
@@ -209,6 +211,70 @@ public class MainShellViewModelTests
         await shell.ExportHtml();   // should be a no-op, not throw
 
         await fs.Received(1).PickExportPathAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task ImportPdf_FillablePdf_LoadsTemplateIntoSessionAsDirty()
+    {
+        var fs = Substitute.For<IFileService>();
+        var pdf = Path.Combine(Path.GetTempPath(), $"imp_{Guid.NewGuid():N}.pdf");
+        await File.WriteAllBytesAsync(pdf, new FillablePdfDocumentRenderer().RenderToBytes(MakeTemplate()));
+        fs.PickPdfImportPathAsync().Returns(pdf);
+
+        var session = new DocumentSessionService();
+        var shell = CreateShell(fs, session: session);
+
+        try
+        {
+            await shell.ImportPdf();
+
+            session.CurrentDocument.Should().NotBeNull("the imported PDF should become the open document");
+            session.CurrentDocument!.DocumentType.Should().Be(DocumentType.Template);
+            session.IsDirty.Should().BeTrue("an import is unsaved until the user picks a path");
+        }
+        finally
+        {
+            if (File.Exists(pdf)) File.Delete(pdf);
+        }
+    }
+
+    [Fact]
+    public async Task ImportPdf_WhenCancelled_NoOp()
+    {
+        var fs = Substitute.For<IFileService>();
+        fs.PickPdfImportPathAsync().Returns((string?)null);
+        var session = new DocumentSessionService();
+        var shell = CreateShell(fs, session: session);
+
+        await shell.ImportPdf();
+
+        session.CurrentDocument.Should().BeNull();
+        await fs.Received(1).PickPdfImportPathAsync();
+    }
+
+    [Fact]
+    public async Task ImportPdf_FlatPdf_ShowsDialog_AndDoesNotOpen()
+    {
+        var fs = Substitute.For<IFileService>();
+        var dlg = Substitute.For<IDialogService>();
+        var pdf = Path.Combine(Path.GetTempPath(), $"flat_{Guid.NewGuid():N}.pdf");
+        await File.WriteAllBytesAsync(pdf, new PdfDocumentRenderer().RenderToBytes(MakeTemplate()));
+        fs.PickPdfImportPathAsync().Returns(pdf);
+
+        var session = new DocumentSessionService();
+        var shell = CreateShell(fs, dialogService: dlg, session: session);
+
+        try
+        {
+            await shell.ImportPdf();
+
+            session.CurrentDocument.Should().BeNull("a flat PDF has no fields to import");
+            await dlg.Received(1).ShowConfirmationAsync(Arg.Any<string>(), Arg.Any<string>());
+        }
+        finally
+        {
+            if (File.Exists(pdf)) File.Delete(pdf);
+        }
     }
 
     private static AprDocument ExprDoc() => new()


### PR DESCRIPTION
Brings the PDF importer to the GUI (where office workers live). **File → Import from PDF…** opens a PDF picker, runs `PdfFormImporter`, and loads the result as a new untitled template (dirty → Save As prompted). Flat/scanned PDFs show a dialog pointing to the `document-to-apr` skill.

- New `IFileService.PickPdfImportPathAsync`; `ImportPdf` command; menu item with `AutomationProperties`.
- 3 VM tests (loads-as-dirty, cancel = no-op, flat-PDF = dialog); Desktop 674→677, a11y 107 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)