### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-07
+
+Import + the web-fill wedge. Bring existing forms into APR two ways — a
+deterministic `apr import` for fillable PDFs and a portable `document-to-apr`
+AI skill for everything else (flat/scanned PDFs, Word, OpenDocument, images) —
+make table cells fillable in both PDF and HTML, and ship accessible HTML /
+self-contained web-form export. See [docs/IMPORT.md](docs/IMPORT.md).
+
 ### Added
 
 - **Desktop File → Import from PDF…** — imports a fillable PDF into a new

--- a/src/PromptResponse.Cli/PromptResponse.Cli.csproj
+++ b/src/PromptResponse.Cli/PromptResponse.Cli.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <PackageId>PromptResponse.Cli</PackageId>
-    <Version>0.4.1</Version>
+    <Version>0.5.0</Version>
     <Authors>PromptResponse Contributors</Authors>
     <Description>Command-line tool for working with APR (Adaptive Prompt Response) files</Description>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>

--- a/src/PromptResponse.Core/PromptResponse.Core.csproj
+++ b/src/PromptResponse.Core/PromptResponse.Core.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <PackageId>PromptResponse.Core</PackageId>
-    <Version>0.4.1</Version>
+    <Version>0.5.0</Version>
     <Authors>PromptResponse Contributors</Authors>
     <Description>Core library for APR (Adaptive Prompt Response) form format</Description>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>

--- a/src/PromptResponse.Desktop/PromptResponse.Desktop.csproj
+++ b/src/PromptResponse.Desktop/PromptResponse.Desktop.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>0.4.1</Version>
+    <Version>0.5.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Cuts **v0.5.0** — the import + web-fill wedge.

**Highlights** (full list in CHANGELOG):
- `apr import` (fillable PDF → APR) + desktop **File → Import from PDF…**
- portable **document-to-apr** skill (PDF/Word/ODF/images), versioned + bundled as a release asset
- **fillable table cells** (HTML + PDF, via pdfe 2.7.0 `FillableTable`)
- accessible **HTML** export + self-contained **fillable web form**
- new **docs/IMPORT.md**

Version 0.4.1 → 0.5.0. Tagging `v0.5.0` after merge triggers the release build (now also attaching the skill zip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)