### PR TITLE
feat: Path A kickoff — richer PDF print (footer, page numbers, page size)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Richer PDF print** (Path A) — flat and fillable PDF export now carry a
+  professional running **footer** on every page (document title · "Generated
+  <date>" · **"Page X of Y"**, above a thin rule) and support a **page size**
+  (Letter / A4 / Legal). CLI: `export --format=pdf --page-size=a4`; the desktop
+  Export menu gets the footer by default. New `PdfRenderOptions`; layout stays in
+  the renderer (the `.apr` format still carries none). First item of the
+  committed **Path A** wedge (see ROADMAP §3).
+
 - **Import quality score + recommendation** — `apr import` now assesses how good
   an import is (no AI) from tooltip coverage, cryptic-label and duplicate-label
   ratios, printing a one-line verdict (e.g. *"Poor (0/100) … use the skill"* for

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,20 +64,26 @@ Platform / quality baseline:
 
 ---
 
-## 3. Strategic question (open) — pick the wedge
+## 3. Strategic wedge — DECIDED: Path A (local-first / sovereignty / accessibility)
 
-The roadmap below is sequenced for the MVP regardless, but **who we optimize
-for after MVP is an unresolved decision** and should be made explicitly:
+> **Decision (2026-06-08): commit to Path A.** After shipping the MVP and a
+> foundation for both wedges, we optimize for the **local-first / sovereignty /
+> accessibility buyer** — public sector, compliance, and privacy-sensitive orgs.
+> It plays to the project's existing strengths (offline, open format, CI-gated
+> WCAG, no vendor lock-in) and competes with PDF/Word rather than entrenched SaaS.
 
-- **A. Local-first / sovereignty / accessibility buyer** — public sector,
-  compliance, privacy-sensitive orgs. Plays to our strengths (offline, open
-  format, CI-gated WCAG, no vendor lock-in). Competes with PDF/Word.
-- **B. Mass-market form builder** — competes with Google/Microsoft Forms,
-  Typeform, JotForm. Requires a web fill path and frictionless sharing; harder
-  fight, larger market.
+The two paths that were on the table:
 
-This choice changes whether Milestone 2 leans into **PDF/signatures/import**
-(A) or **web fill + sharing** (B). It does **not** change the MVP.
+- **A. Local-first / sovereignty / accessibility buyer** *(chosen)* — public
+  sector, compliance, privacy-sensitive orgs. Offline, open format, CI-gated
+  WCAG, no vendor lock-in. Competes with PDF/Word.
+- **B. Mass-market form builder** *(deferred)* — competes with Google/Microsoft
+  Forms, Typeform, JotForm. Requires a web fill path + frictionless sharing.
+  Its foundation (HTML renderer + self-contained fillable web form) is built and
+  kept warm, but we are **not** investing in a hosted/shareable app now.
+
+Path A means Milestone 2 leans into **richer print, a submission/signature
+story, and deeper import** (see Milestone 2 below), not web fill + sharing.
 
 ---
 
@@ -115,11 +121,22 @@ What makes APR competitive with advanced form systems, not just usable:
 - **Conditional logic** — show/hide and conditional-required rules; repeatable
   sections (e.g. multiple dependents). Advisory, never input-blocking.
 - **Validation panel** — dedicated warnings panel, click-to-field.
-- **Wedge-dependent (pick per §3):**
-  - *Path A:* import tooling (Word/PDF → APR), digital-signature story for
-    submission (decide in/out of format scope), richer print templates.
-  - *Path B:* browser fill path (Blazor/WASM or static HTML renderer — the
-    Python server proves the shape) + shareable form links.
+- **Wedge — Path A (chosen, §3):** the local-first / accessibility direction.
+  Sequenced by value × low risk:
+  1. **Richer print / PDF templates** *(in progress)* — running header/footer,
+     "Page X of Y", a document title block + generated date, A4/Letter page
+     size. The presentable, archival artifact gov/compliance actually submit and
+     file. Done in the PDF renderer (no format/layout added to `.apr`).
+  2. **Deeper import** — done: `apr import` (AcroForm → APR) with self-scoring
+     quality, the portable `document-to-apr` skill, and the importer→skill hybrid.
+     Follow-ups: radio-groups → choice, richer sectioning (see #64).
+  3. **Submission / signature story** — reintroduce a signature/attestation path
+     for submitted forms (was purged in #12 for the clean Phase-1 base). Decide
+     in-format vs out-of-format scope; pdfe can author AcroForm signature fields.
+  4. **PDF/A archival output** — long-term-preservation profile for records.
+
+  *Path B (deferred):* the browser fill path foundation (HTML renderer +
+  fillable web form) exists; a hosted/shareable app is not in the near-term plan.
 
 ### Milestone 3 — Reach (target: v0.5.x+)
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -80,7 +80,7 @@ Cross-reference with ROADMAP.md for detailed descriptions.
 | CSV/JSON/TXT export | P1 | ✅ | Via CLI export command |
 | HTML export | P2 | ✅ | Accessible HTML page (`export --format=html`); foundation for a browser fill path |
 | Fillable HTML (browser fill) | P1 | ✅ | `export --format=html --fillable` → self-contained interactive web form that downloads `.aprf`; no server. CLI + desktop File → Export |
-| **PDF export** | **P1** | **✅** | Flat **and** fillable-AcroForm PDF via CLI (`export --format=pdf [--fillable]`) and the desktop File → Export menu (pdfe engine); carries document metadata. Unicode text rendering through the builder is the remaining gap (pdfe#398) (#31) |
+| **PDF export** | **P1** | **✅** | Flat **and** fillable-AcroForm PDF via CLI (`export --format=pdf [--fillable] [--page-size=a4]`) and the desktop File → Export menu (pdfe engine); carries document metadata, a running footer (title · generated date · "Page X of Y"), and a page-size option (Letter/A4/Legal). Unicode text rendering through the builder is the remaining gap (pdfe#398) (#31) |
 | Word export (.docx) | P2 | ⏳ | Export to Word format |
 | Excel export (.xlsx) | P2 | ⏳ | Export to spreadsheet |
 

--- a/src/PromptResponse.Cli/Commands/ExportCommand.cs
+++ b/src/PromptResponse.Cli/Commands/ExportCommand.cs
@@ -34,8 +34,9 @@ public class ExportCommand : ICommand
             Console.Error.WriteLine("  pdf  - Flattened PDF (requires --output)");
             Console.Error.WriteLine();
             Console.Error.WriteLine("Options:");
-            Console.Error.WriteLine("  --exclude-empty  Omit unanswered fields (pdf)");
-            Console.Error.WriteLine("  --fillable       Export a fillable form with live fields (pdf, html)");
+            Console.Error.WriteLine("  --exclude-empty       Omit unanswered fields (pdf)");
+            Console.Error.WriteLine("  --fillable            Export a fillable form with live fields (pdf, html)");
+            Console.Error.WriteLine("  --page-size=<size>    letter (default), a4, or legal (pdf)");
             return 1;
         }
 
@@ -73,7 +74,8 @@ public class ExportCommand : ICommand
             // PDF is binary: render to a file via the shared IDocumentRenderer seam.
             if (format.Equals("pdf", StringComparison.OrdinalIgnoreCase))
             {
-                return await ExportToPdfAsync(document, outputPath, excludeEmpty, fillable);
+                var pageSize = ParsePageSize(GetArgValue(args, "--page-size"));
+                return await ExportToPdfAsync(document, outputPath, excludeEmpty, fillable, pageSize);
             }
 
             // Generate export
@@ -117,7 +119,14 @@ public class ExportCommand : ICommand
         return arg?.Substring(prefix.Length + 1);
     }
 
-    private static async Task<int> ExportToPdfAsync(AprDocument document, string? outputPath, bool excludeEmpty, bool fillable)
+    private static PdfPageSize ParsePageSize(string? value) => value?.ToLowerInvariant() switch
+    {
+        "a4" => PdfPageSize.A4,
+        "legal" => PdfPageSize.Legal,
+        _ => PdfPageSize.Letter,
+    };
+
+    private static async Task<int> ExportToPdfAsync(AprDocument document, string? outputPath, bool excludeEmpty, bool fillable, PdfPageSize pageSize)
     {
         // A PDF is binary, so it must be written to a file rather than stdout.
         if (string.IsNullOrEmpty(outputPath))
@@ -126,10 +135,12 @@ public class ExportCommand : ICommand
             return 1;
         }
 
+        var print = new PdfRenderOptions { PageSize = pageSize };
+
         // --fillable produces an interactive AcroForm; otherwise a flat PDF.
         IDocumentRenderer renderer = fillable
-            ? new FillablePdfDocumentRenderer()
-            : new PdfDocumentRenderer();
+            ? new FillablePdfDocumentRenderer(print: print)
+            : new PdfDocumentRenderer(print: print);
         var options = new RenderOptions { IncludeEmptyFields = !excludeEmpty };
 
         await using (var stream = File.Create(outputPath))

--- a/src/PromptResponse.Rendering.Pdf/FillablePdfDocumentRenderer.cs
+++ b/src/PromptResponse.Rendering.Pdf/FillablePdfDocumentRenderer.cs
@@ -38,14 +38,17 @@ public sealed class FillablePdfDocumentRenderer : IDocumentRenderer
         new(StringComparer.OrdinalIgnoreCase) { "true", "yes", "y", "1", "x", "checked", "on" };
 
     private readonly IDocumentRenderModelBuilder _builder;
+    private readonly PdfRenderOptions _print;
 
     /// <summary>
     /// Initializes the renderer, optionally with a custom model builder
-    /// (defaults to <see cref="DocumentRenderModelBuilder"/>).
+    /// (defaults to <see cref="DocumentRenderModelBuilder"/>) and print options
+    /// (page size + running footer; defaults to <see cref="PdfRenderOptions.Default"/>).
     /// </summary>
-    public FillablePdfDocumentRenderer(IDocumentRenderModelBuilder? builder = null)
+    public FillablePdfDocumentRenderer(IDocumentRenderModelBuilder? builder = null, PdfRenderOptions? print = null)
     {
         _builder = builder ?? new DocumentRenderModelBuilder();
+        _print = print ?? PdfRenderOptions.Default;
     }
 
     /// <inheritdoc />
@@ -69,7 +72,7 @@ public sealed class FillablePdfDocumentRenderer : IDocumentRenderer
             EmptyFieldText = options.EmptyFieldText,
         };
         var model = _builder.Build(document, formOptions);
-        var pdf = PdfDocumentBuilder.Create();
+        var pdf = PdfDocumentBuilder.Create(PdfRenderHelpers.ToPageSize(_print.PageSize));
         PdfRenderHelpers.ApplyMetadata(pdf, document.Metadata);
 
         var title = string.IsNullOrWhiteSpace(model.Title) ? "(untitled)" : model.Title;
@@ -84,7 +87,9 @@ public sealed class FillablePdfDocumentRenderer : IDocumentRenderer
             WriteBlock(pdf, block);
         }
 
-        pdf.Save(output);
+        var doc = pdf.Build();
+        PdfRenderHelpers.ApplyRunningFooter(doc, _print, title);
+        doc.Save(output);
     }
 
     private static void WriteBlock(PdfDocumentBuilder pdf, RenderBlock block)

--- a/src/PromptResponse.Rendering.Pdf/PdfDocumentRenderer.cs
+++ b/src/PromptResponse.Rendering.Pdf/PdfDocumentRenderer.cs
@@ -32,14 +32,17 @@ public sealed class PdfDocumentRenderer : IDocumentRenderer
         TextStyle.Body.WithSize(8).WithColor(PdfColor.FromGray(0.4));
 
     private readonly IDocumentRenderModelBuilder _builder;
+    private readonly PdfRenderOptions _print;
 
     /// <summary>
     /// Initializes the renderer, optionally with a custom model builder
-    /// (defaults to <see cref="DocumentRenderModelBuilder"/>).
+    /// (defaults to <see cref="DocumentRenderModelBuilder"/>) and print options
+    /// (page size + running footer; defaults to <see cref="PdfRenderOptions.Default"/>).
     /// </summary>
-    public PdfDocumentRenderer(IDocumentRenderModelBuilder? builder = null)
+    public PdfDocumentRenderer(IDocumentRenderModelBuilder? builder = null, PdfRenderOptions? print = null)
     {
         _builder = builder ?? new DocumentRenderModelBuilder();
+        _print = print ?? PdfRenderOptions.Default;
     }
 
     /// <inheritdoc />
@@ -56,7 +59,7 @@ public sealed class PdfDocumentRenderer : IDocumentRenderer
         ArgumentNullException.ThrowIfNull(output);
 
         var model = _builder.Build(document, options);
-        var pdf = PdfDocumentBuilder.Create();
+        var pdf = PdfDocumentBuilder.Create(PdfRenderHelpers.ToPageSize(_print.PageSize));
         PdfRenderHelpers.ApplyMetadata(pdf, document.Metadata);
 
         var title = string.IsNullOrWhiteSpace(model.Title) ? "(untitled)" : model.Title;
@@ -71,7 +74,10 @@ public sealed class PdfDocumentRenderer : IDocumentRenderer
             WriteBlock(pdf, block);
         }
 
-        pdf.Save(output);
+        // Build, stamp the running footer (needs the final page count), then save.
+        var doc = pdf.Build();
+        PdfRenderHelpers.ApplyRunningFooter(doc, _print, title);
+        doc.Save(output);
     }
 
     private static void WriteBlock(PdfDocumentBuilder pdf, RenderBlock block)

--- a/src/PromptResponse.Rendering.Pdf/PdfRenderHelpers.cs
+++ b/src/PromptResponse.Rendering.Pdf/PdfRenderHelpers.cs
@@ -1,4 +1,6 @@
 using Pdfe.Core.Authoring;
+using Pdfe.Core.Document;
+using Pdfe.Core.Graphics;
 using PromptResponse.Core.Models;
 using PromptResponse.Core.Rendering;
 
@@ -9,6 +11,67 @@ namespace PromptResponse.Rendering.Pdf;
 /// </summary>
 internal static class PdfRenderHelpers
 {
+    /// <summary>Maps the renderer's page-size option to a pdfe <see cref="PageSize"/>.</summary>
+    public static PageSize ToPageSize(PdfPageSize size) => size switch
+    {
+        PdfPageSize.A4 => PageSize.A4,
+        PdfPageSize.Legal => PageSize.Legal,
+        _ => PageSize.Letter,
+    };
+
+    /// <summary>
+    /// Draws a running footer on every page of an already-built document: the
+    /// footer label on the left, a generated date in the centre, and "Page X of
+    /// Y" on the right, above a thin rule. Runs after layout (so the page total is
+    /// known) and appends to each page's content, sitting inside the bottom
+    /// margin so it never overlaps the form body.
+    /// </summary>
+    public static void ApplyRunningFooter(PdfDocument doc, PdfRenderOptions options, string title)
+    {
+        if (!options.ShowFooter)
+        {
+            return;
+        }
+
+        var font = PdfFont.Helvetica(8);
+        var brush = PdfBrush.Black;
+        var pen = new PdfPen(PdfColor.FromGray(0.75), 0.5);
+
+        var label = string.IsNullOrWhiteSpace(options.FooterLabel) ? title : options.FooterLabel!;
+        var date = options.ShowGeneratedDate
+            ? options.GeneratedOn ?? DateTime.Now.ToString("yyyy-MM-dd")
+            : null;
+
+        var total = doc.PageCount;
+        const double margin = 72, footerY = 30, ruleY = 46;
+
+        for (var i = 1; i <= total; i++)
+        {
+            var page = doc.GetPage(i);
+            var g = page.GetGraphics();
+            double left = margin, right = page.Width - margin, centre = page.Width / 2;
+
+            g.DrawLine(left, ruleY, right, ruleY, pen);
+
+            if (!string.IsNullOrWhiteSpace(label))
+            {
+                g.DrawString(Truncate(label, 70), font, brush, left, footerY, TextAlignment.Left);
+            }
+            if (date != null)
+            {
+                g.DrawString($"Generated {date}", font, brush, centre, footerY, TextAlignment.Center);
+            }
+            if (options.ShowPageNumbers)
+            {
+                g.DrawString($"Page {i} of {total}", font, brush, right, footerY, TextAlignment.Right);
+            }
+
+            g.Flush();
+        }
+    }
+
+    private static string Truncate(string s, int max) => s.Length <= max ? s : s[..(max - 1)] + "...";
+
     /// <summary>
     /// Stamps the document's metadata onto the PDF Info dictionary (Title /
     /// Author / Subject) using pdfe v2.5.0's metadata authoring, for provenance

--- a/src/PromptResponse.Rendering.Pdf/PdfRenderOptions.cs
+++ b/src/PromptResponse.Rendering.Pdf/PdfRenderOptions.cs
@@ -1,0 +1,52 @@
+namespace PromptResponse.Rendering.Pdf;
+
+/// <summary>Page size for PDF output.</summary>
+public enum PdfPageSize
+{
+    /// <summary>US Letter (8.5 × 11 in).</summary>
+    Letter,
+
+    /// <summary>ISO A4 (210 × 297 mm).</summary>
+    A4,
+
+    /// <summary>US Legal (8.5 × 14 in).</summary>
+    Legal,
+}
+
+/// <summary>
+/// Print/layout options for the PDF renderers — concerns that are renderer-
+/// specific and deliberately kept out of the format-agnostic
+/// <see cref="Core.Rendering.RenderOptions"/> (the <c>.apr</c> format carries no
+/// layout). Controls page size and the running footer (page numbers, a footer
+/// label, and a generated date) that make the output a presentable, archival
+/// artifact.
+/// </summary>
+public sealed class PdfRenderOptions
+{
+    /// <summary>The page size. Defaults to US Letter.</summary>
+    public PdfPageSize PageSize { get; init; } = PdfPageSize.Letter;
+
+    /// <summary>Whether to draw a running footer at the bottom of every page.</summary>
+    public bool ShowFooter { get; init; } = true;
+
+    /// <summary>Whether the footer includes a "Page X of Y" indicator.</summary>
+    public bool ShowPageNumbers { get; init; } = true;
+
+    /// <summary>Whether the footer includes a generated/printed date.</summary>
+    public bool ShowGeneratedDate { get; init; } = true;
+
+    /// <summary>
+    /// The left-hand footer label. When null/blank, the document title is used.
+    /// </summary>
+    public string? FooterLabel { get; init; }
+
+    /// <summary>
+    /// A pre-formatted date string for the footer (e.g. "2026-06-08"). When null
+    /// and <see cref="ShowGeneratedDate"/> is set, the render-time date is used.
+    /// Provided explicitly mainly so output is deterministic for tests.
+    /// </summary>
+    public string? GeneratedOn { get; init; }
+
+    /// <summary>Default options: Letter, footer with page numbers and date.</summary>
+    public static PdfRenderOptions Default { get; } = new();
+}

--- a/tests/PromptResponse.Rendering.Pdf.Tests/PdfDocumentRendererTests.cs
+++ b/tests/PromptResponse.Rendering.Pdf.Tests/PdfDocumentRendererTests.cs
@@ -176,4 +176,39 @@ public class PdfDocumentRendererTests
         var act = () => _renderer.RenderToBytes(null!);
         act.Should().Throw<ArgumentNullException>();
     }
+
+    [Fact]
+    public void Render_DrawsRunningFooter_WithPageNumbersAndGeneratedDate()
+    {
+        var renderer = new PdfDocumentRenderer(print: new PdfRenderOptions { GeneratedOn = "2026-01-01" });
+
+        var bytes = renderer.RenderToBytes(SampleDoc());
+
+        using var doc = PdfeDoc.Open(bytes);
+        var text = doc.GetPage(1).Text;
+        text.Should().Contain("Page 1 of 1");
+        text.Should().Contain("Generated 2026-01-01");
+    }
+
+    [Fact]
+    public void Render_A4_ProducesA4SizedPages()
+    {
+        var renderer = new PdfDocumentRenderer(print: new PdfRenderOptions { PageSize = PdfPageSize.A4 });
+
+        var bytes = renderer.RenderToBytes(SampleDoc());
+
+        using var doc = PdfeDoc.Open(bytes);
+        doc.GetPage(1).Width.Should().BeApproximately(595.28, 1.0, "A4 is 595.28 pt wide");
+    }
+
+    [Fact]
+    public void Render_FooterDisabled_OmitsPageNumbers()
+    {
+        var renderer = new PdfDocumentRenderer(print: new PdfRenderOptions { ShowFooter = false });
+
+        var bytes = renderer.RenderToBytes(SampleDoc());
+
+        using var doc = PdfeDoc.Open(bytes);
+        doc.GetPage(1).Text.Should().NotContain("Page 1 of");
+    }
 }


### PR DESCRIPTION
**Commits the wedge to Path A** (local-first / sovereignty / accessibility) in ROADMAP §3, and ships its first item.

Flat **and** fillable PDF export now carry a professional **running footer** on every page — title · *Generated <date>* · **Page X of Y**, above a thin rule — and a **page size** option (Letter / A4 / Legal). The presentable, archival artifact gov/compliance actually submit and file.

- New `PdfRenderOptions`; done entirely in the renderer via pdfe's public graphics (post-`Build()` page pass once the page count is known) — **no layout added to `.apr`**, no pdfe change.
- CLI: `export --format=pdf --page-size=a4`; desktop Export menu gets the footer by default.
- 3 renderer round-trip tests; full sweep green (Core 496, CLI 106, PDF 28, Desktop 679, a11y 107); visually verified via poppler.

Next Path A items (ROADMAP §4): deeper import follow-ups, a submission/signature story, PDF/A archival.

🤖 Generated with [Claude Code](https://claude.com/claude-code)