### PR TITLE
feat: classification/handling banner markings (Path A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Export menu gets the footer by default. New `PdfRenderOptions`; layout stays in
   the renderer (the `.apr` format still carries none). First item of the
   committed **Path A** wedge (see ROADMAP §3).
+- **Classification / handling banner markings** (Path A) — `export --format=pdf
+  --banner="CONTROLLED UNCLASSIFIED INFORMATION"` stamps a bold, centered banner
+  at the top **and** bottom of every page (in the margins, never overlapping the
+  body) — for public-sector / compliance handling markings (CUI, FOUO, OFFICIAL,
+  DRAFT, CONFIDENTIAL).
 
 - **Import quality score + recommendation** — `apr import` now assesses how good
   an import is (no AI) from tooltip coverage, cryptic-label and duplicate-label

--- a/src/PromptResponse.Cli/Commands/ExportCommand.cs
+++ b/src/PromptResponse.Cli/Commands/ExportCommand.cs
@@ -37,6 +37,7 @@ public class ExportCommand : ICommand
             Console.Error.WriteLine("  --exclude-empty       Omit unanswered fields (pdf)");
             Console.Error.WriteLine("  --fillable            Export a fillable form with live fields (pdf, html)");
             Console.Error.WriteLine("  --page-size=<size>    letter (default), a4, or legal (pdf)");
+            Console.Error.WriteLine("  --banner=<text>       Classification/handling banner on every page (pdf), e.g. \"OFFICIAL\"");
             return 1;
         }
 
@@ -75,7 +76,8 @@ public class ExportCommand : ICommand
             if (format.Equals("pdf", StringComparison.OrdinalIgnoreCase))
             {
                 var pageSize = ParsePageSize(GetArgValue(args, "--page-size"));
-                return await ExportToPdfAsync(document, outputPath, excludeEmpty, fillable, pageSize);
+                var banner = GetArgValue(args, "--banner");
+                return await ExportToPdfAsync(document, outputPath, excludeEmpty, fillable, pageSize, banner);
             }
 
             // Generate export
@@ -126,7 +128,7 @@ public class ExportCommand : ICommand
         _ => PdfPageSize.Letter,
     };
 
-    private static async Task<int> ExportToPdfAsync(AprDocument document, string? outputPath, bool excludeEmpty, bool fillable, PdfPageSize pageSize)
+    private static async Task<int> ExportToPdfAsync(AprDocument document, string? outputPath, bool excludeEmpty, bool fillable, PdfPageSize pageSize, string? banner)
     {
         // A PDF is binary, so it must be written to a file rather than stdout.
         if (string.IsNullOrEmpty(outputPath))
@@ -135,7 +137,7 @@ public class ExportCommand : ICommand
             return 1;
         }
 
-        var print = new PdfRenderOptions { PageSize = pageSize };
+        var print = new PdfRenderOptions { PageSize = pageSize, BannerText = banner };
 
         // --fillable produces an interactive AcroForm; otherwise a flat PDF.
         IDocumentRenderer renderer = fillable

--- a/src/PromptResponse.Rendering.Pdf/FillablePdfDocumentRenderer.cs
+++ b/src/PromptResponse.Rendering.Pdf/FillablePdfDocumentRenderer.cs
@@ -88,7 +88,7 @@ public sealed class FillablePdfDocumentRenderer : IDocumentRenderer
         }
 
         var doc = pdf.Build();
-        PdfRenderHelpers.ApplyRunningFooter(doc, _print, title);
+        PdfRenderHelpers.ApplyRunningElements(doc, _print, title);
         doc.Save(output);
     }
 

--- a/src/PromptResponse.Rendering.Pdf/PdfDocumentRenderer.cs
+++ b/src/PromptResponse.Rendering.Pdf/PdfDocumentRenderer.cs
@@ -74,9 +74,9 @@ public sealed class PdfDocumentRenderer : IDocumentRenderer
             WriteBlock(pdf, block);
         }
 
-        // Build, stamp the running footer (needs the final page count), then save.
+        // Build, stamp running elements (footer/banner need the final page count), then save.
         var doc = pdf.Build();
-        PdfRenderHelpers.ApplyRunningFooter(doc, _print, title);
+        PdfRenderHelpers.ApplyRunningElements(doc, _print, title);
         doc.Save(output);
     }
 

--- a/src/PromptResponse.Rendering.Pdf/PdfRenderHelpers.cs
+++ b/src/PromptResponse.Rendering.Pdf/PdfRenderHelpers.cs
@@ -20,20 +20,23 @@ internal static class PdfRenderHelpers
     };
 
     /// <summary>
-    /// Draws a running footer on every page of an already-built document: the
-    /// footer label on the left, a generated date in the centre, and "Page X of
-    /// Y" on the right, above a thin rule. Runs after layout (so the page total is
-    /// known) and appends to each page's content, sitting inside the bottom
-    /// margin so it never overlaps the form body.
+    /// Draws running page elements on every page of an already-built document:
+    /// an optional classification/handling banner (centered, bold, top and
+    /// bottom) and a footer (label left, generated date centre, "Page X of Y"
+    /// right, above a thin rule). Runs after layout (so the page total is known),
+    /// appends to each page's content, and sits inside the margins so nothing
+    /// overlaps the form body.
     /// </summary>
-    public static void ApplyRunningFooter(PdfDocument doc, PdfRenderOptions options, string title)
+    public static void ApplyRunningElements(PdfDocument doc, PdfRenderOptions options, string title)
     {
-        if (!options.ShowFooter)
+        var banner = string.IsNullOrWhiteSpace(options.BannerText) ? null : options.BannerText!.Trim();
+        if (!options.ShowFooter && banner is null)
         {
             return;
         }
 
         var font = PdfFont.Helvetica(8);
+        var bannerFont = PdfFont.HelveticaBold(9);
         var brush = PdfBrush.Black;
         var pen = new PdfPen(PdfColor.FromGray(0.75), 0.5);
 
@@ -43,7 +46,7 @@ internal static class PdfRenderHelpers
             : null;
 
         var total = doc.PageCount;
-        const double margin = 72, footerY = 30, ruleY = 46;
+        const double margin = 72, footerY = 30, ruleY = 46, bottomBannerY = 14;
 
         for (var i = 1; i <= total; i++)
         {
@@ -51,19 +54,28 @@ internal static class PdfRenderHelpers
             var g = page.GetGraphics();
             double left = margin, right = page.Width - margin, centre = page.Width / 2;
 
-            g.DrawLine(left, ruleY, right, ruleY, pen);
+            if (banner is not null)
+            {
+                // Top and bottom handling markings, in the page margins.
+                g.DrawString(banner, bannerFont, brush, centre, page.Height - 30, TextAlignment.Center);
+                g.DrawString(banner, bannerFont, brush, centre, bottomBannerY, TextAlignment.Center);
+            }
 
-            if (!string.IsNullOrWhiteSpace(label))
+            if (options.ShowFooter)
             {
-                g.DrawString(Truncate(label, 70), font, brush, left, footerY, TextAlignment.Left);
-            }
-            if (date != null)
-            {
-                g.DrawString($"Generated {date}", font, brush, centre, footerY, TextAlignment.Center);
-            }
-            if (options.ShowPageNumbers)
-            {
-                g.DrawString($"Page {i} of {total}", font, brush, right, footerY, TextAlignment.Right);
+                g.DrawLine(left, ruleY, right, ruleY, pen);
+                if (!string.IsNullOrWhiteSpace(label))
+                {
+                    g.DrawString(Truncate(label, 70), font, brush, left, footerY, TextAlignment.Left);
+                }
+                if (date != null)
+                {
+                    g.DrawString($"Generated {date}", font, brush, centre, footerY, TextAlignment.Center);
+                }
+                if (options.ShowPageNumbers)
+                {
+                    g.DrawString($"Page {i} of {total}", font, brush, right, footerY, TextAlignment.Right);
+                }
             }
 
             g.Flush();

--- a/src/PromptResponse.Rendering.Pdf/PdfRenderOptions.cs
+++ b/src/PromptResponse.Rendering.Pdf/PdfRenderOptions.cs
@@ -47,6 +47,15 @@ public sealed class PdfRenderOptions
     /// </summary>
     public string? GeneratedOn { get; init; }
 
+    /// <summary>
+    /// An optional classification / handling banner marking drawn centered and
+    /// bold at the top <em>and</em> bottom of every page (in the margins, so it
+    /// never overlaps the form body). For public-sector / compliance handling
+    /// markings such as "CONTROLLED UNCLASSIFIED INFORMATION", "FOR OFFICIAL USE
+    /// ONLY", "OFFICIAL", "DRAFT", or "CONFIDENTIAL". Null/blank = no banner.
+    /// </summary>
+    public string? BannerText { get; init; }
+
     /// <summary>Default options: Letter, footer with page numbers and date.</summary>
     public static PdfRenderOptions Default { get; } = new();
 }

--- a/tests/PromptResponse.Rendering.Pdf.Tests/PdfDocumentRendererTests.cs
+++ b/tests/PromptResponse.Rendering.Pdf.Tests/PdfDocumentRendererTests.cs
@@ -211,4 +211,22 @@ public class PdfDocumentRendererTests
         using var doc = PdfeDoc.Open(bytes);
         doc.GetPage(1).Text.Should().NotContain("Page 1 of");
     }
+
+    [Fact]
+    public void Render_Banner_AppearsTopAndBottomOfEveryPage()
+    {
+        var renderer = new PdfDocumentRenderer(print: new PdfRenderOptions
+        {
+            BannerText = "CONTROLLED UNCLASSIFIED INFORMATION",
+            ShowFooter = false,
+        });
+
+        var bytes = renderer.RenderToBytes(SampleDoc());
+
+        using var doc = PdfeDoc.Open(bytes);
+        var text = doc.GetPage(1).Text;
+        // Drawn at both the top and bottom margin → appears twice.
+        System.Text.RegularExpressions.Regex.Matches(text, "CONTROLLED UNCLASSIFIED INFORMATION")
+            .Count.Should().Be(2);
+    }
 }


### PR DESCRIPTION
Second Path A print feature. `export --format=pdf --banner="CONTROLLED UNCLASSIFIED INFORMATION"` stamps a bold, centered banner at the **top and bottom** of every page — drawn in the margins (same post-`Build()` pass as the footer), so it never overlaps the body.

For the public-sector/compliance audience: CUI, FOUO, OFFICIAL, DRAFT, CONFIDENTIAL handling markings — a real gov-document requirement competitors don't serve. `PdfRenderOptions.BannerText`; the footer helper became `ApplyRunningElements`.

Test (banner appears top+bottom); full sweep green; visually verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)