### PR TITLE
feat: verifiable APR signatures — foundation (apr-sig-v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Verifiable signatures — foundation** (Path A) — `apr-sig-v1`: detached ECDSA
+  P-256 / SHA-256 signatures over APR content, using only built-in .NET crypto
+  (no new dependency). A **publisher signs the template** (and the signature
+  **binds the submission URL** so it can't be redirected); **fillers sign the
+  responses in their scope**, and multiple signers can each cover the parts they
+  filled. Tamper-evident (editing a covered field invalidates its signatures),
+  scope-isolated (out-of-scope edits don't), and signatures survive JSON
+  round-trips. Pure data + pure-computation verification (consistent with "no
+  code execution"). New `PromptResponse.Core.Signing` (`AprSigner`,
+  `AprVerifier`, `AprCanonicalizer`, `SignatureKeys`), a `Signature`/`Signer`
+  model + `metadata.publisher`/`submissionUrl`. CLI (`keygen`/`sign`/`verify`),
+  desktop UI, and rendering of signature status follow. (Issue #73)
+
 - **Richer PDF print** (Path A) — flat and fillable PDF export now carry a
   professional running **footer** on every page (document title · "Generated
   <date>" · **"Page X of Y"**, above a thin rule) and support a **page size**

--- a/src/PromptResponse.Core/Models/AprDocument.cs
+++ b/src/PromptResponse.Core/Models/AprDocument.cs
@@ -45,4 +45,18 @@ public class AprDocument
     /// A document must have at least one section (enforced by validation, not by this model).
     /// </remarks>
     public List<Section> Sections { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the detached cryptographic signatures over this document.
+    /// </summary>
+    /// <remarks>
+    /// Pure data — verification is a side-effect-free computation, consistent with
+    /// the "no code execution, safe to open untrusted" principle. A publisher
+    /// signature attests to the form definition (and binds the submission URL); a
+    /// filler signature attests to the responses in its scope. Editing a covered
+    /// field invalidates the signatures that cover it. See
+    /// <c>PromptResponse.Core.Signing</c>. Null/absent when the document is
+    /// unsigned, so unsigned files carry no signatures field.
+    /// </remarks>
+    public List<Signature>? Signatures { get; set; }
 }

--- a/src/PromptResponse.Core/Models/Metadata.cs
+++ b/src/PromptResponse.Core/Models/Metadata.cs
@@ -98,4 +98,27 @@ public class Metadata
     /// Should be UTC timestamp.
     /// </remarks>
     public DateTime? FilledDate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the publisher of the form (the organization or person that
+    /// authored and stands behind the template).
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <see cref="Author"/> (a person). When the template is signed
+    /// by the publisher, the publisher signature's signer identity is the
+    /// authoritative, verifiable form of this.
+    /// </remarks>
+    /// <example>"Town of Bloomfield, CT", "U.S. Office of Personnel Management"</example>
+    public string? Publisher { get; set; }
+
+    /// <summary>
+    /// Gets or sets the URL describing how to submit the completed form.
+    /// </summary>
+    /// <remarks>
+    /// When the template carries a publisher signature, this URL is bound into the
+    /// signed payload so it cannot be altered to redirect submissions without
+    /// invalidating the signature.
+    /// </remarks>
+    /// <example>"https://bloomfieldct.gov/forms/permit/submit"</example>
+    public string? SubmissionUrl { get; set; }
 }

--- a/src/PromptResponse.Core/Models/Signature.cs
+++ b/src/PromptResponse.Core/Models/Signature.cs
@@ -1,0 +1,80 @@
+namespace PromptResponse.Core.Models;
+
+/// <summary>The role a signature plays in an APR document.</summary>
+public enum SignatureRole
+{
+    /// <summary>
+    /// The publisher of the form attesting to the template definition (and the
+    /// bound submission URL) — proves authenticity and that the form is unaltered.
+    /// </summary>
+    Publisher,
+
+    /// <summary>
+    /// A person who filled the form attesting to the responses in their scope.
+    /// </summary>
+    Filler,
+}
+
+/// <summary>The identity of a signer.</summary>
+public class Signer
+{
+    /// <summary>Human-readable signer name (e.g. "Town of Bloomfield, CT", "Ada Lovelace").</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Optional stable identifier (email, org id, DID, …).</summary>
+    public string? Identifier { get; set; }
+
+    /// <summary>
+    /// The signer's public key as a PEM-encoded SubjectPublicKeyInfo block, used
+    /// to verify <see cref="Signature.Value"/>. (An X.509 certificate chain is a
+    /// planned additive alternative for PKI trust.)
+    /// </summary>
+    public string PublicKey { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// A detached cryptographic signature over part of an APR document. Pure data;
+/// produced and verified by <c>PromptResponse.Core.Signing</c>.
+/// </summary>
+public class Signature
+{
+    /// <summary>A stable id for this signature (unique within the document).</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Whether this is a publisher or a filler signature.</summary>
+    public SignatureRole Role { get; set; }
+
+    /// <summary>The signer's identity and public key.</summary>
+    public Signer Signer { get; set; } = new();
+
+    /// <summary>
+    /// What the signature covers: <c>"template"</c> (the whole form definition, for
+    /// a publisher) or <c>"fields"</c> (the prompts listed in <see cref="Fields"/>,
+    /// for a filler).
+    /// </summary>
+    public string Scope { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The prompt ids this signature covers when <see cref="Scope"/> is
+    /// <c>"fields"</c>. The signer attests to these prompts' current responses.
+    /// </summary>
+    public List<string> Fields { get; set; } = new();
+
+    /// <summary>
+    /// For a publisher signature, the submission URL bound into the signed payload
+    /// (so it cannot be altered without invalidating the signature).
+    /// </summary>
+    public string? SubmissionUrl { get; set; }
+
+    /// <summary>The signature algorithm (default <c>ecdsa-p256-sha256</c>).</summary>
+    public string Algorithm { get; set; } = "ecdsa-p256-sha256";
+
+    /// <summary>The canonical-payload scheme version (default <c>apr-sig-v1</c>).</summary>
+    public string Canonicalization { get; set; } = "apr-sig-v1";
+
+    /// <summary>When the signature was produced (ISO-8601 UTC).</summary>
+    public string SignedAt { get; set; } = string.Empty;
+
+    /// <summary>The base64-encoded signature bytes.</summary>
+    public string Value { get; set; } = string.Empty;
+}

--- a/src/PromptResponse.Core/Signing/AprCanonicalizer.cs
+++ b/src/PromptResponse.Core/Signing/AprCanonicalizer.cs
@@ -1,0 +1,190 @@
+using System.Security.Cryptography;
+using System.Text;
+using PromptResponse.Core.Models;
+
+namespace PromptResponse.Core.Signing;
+
+/// <summary>
+/// Produces the canonical byte payloads that APR signatures are computed over
+/// (scheme <c>apr-sig-v1</c>). The format is deliberately simple and
+/// language-portable — a fixed, ordered list of <c>label=base64(value)</c> lines —
+/// rather than full JSON canonicalization, so other SDKs can reproduce it exactly
+/// and signatures survive re-serialization.
+/// </summary>
+/// <remarks>
+/// Two payload shapes:
+/// <list type="bullet">
+///   <item><b>Publisher</b> — template id/version, the bound submission URL, and a
+///   digest of the <em>form definition</em> (structure/labels/hints, excluding
+///   responses and the signatures array).</item>
+///   <item><b>Filler</b> — template id/version and the sorted
+///   <c>(fieldId, response)</c> pairs in the signer's scope.</item>
+/// </list>
+/// Both include the signer identity + public key + timestamp.
+/// </remarks>
+public static class AprCanonicalizer
+{
+    /// <summary>The canonical-payload scheme version.</summary>
+    public const string Scheme = "apr-sig-v1";
+
+    /// <summary>The bytes a publisher signs: form definition + bound submission URL.</summary>
+    public static byte[] PublisherPayload(AprDocument document, Signer signer, string? submissionUrl, string signedAt)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(signer);
+
+        return new Writer()
+            .Add("scheme", Scheme)
+            .Add("role", "publisher")
+            .Add("templateId", document.Metadata.TemplateId)
+            .Add("templateVersion", document.Metadata.TemplateVersion)
+            .Add("submissionUrl", submissionUrl)
+            .Add("formDefDigest", Sha256Hex(FormDefinition(document)))
+            .Add("signer.name", signer.Name)
+            .Add("signer.id", signer.Identifier)
+            .Add("signer.key", signer.PublicKey)
+            .Add("signedAt", signedAt)
+            .ToBytes();
+    }
+
+    /// <summary>The bytes a filler signs: the responses of the covered fields.</summary>
+    public static byte[] FillerPayload(AprDocument document, IEnumerable<string> fields, Signer signer, string signedAt)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(fields);
+        ArgumentNullException.ThrowIfNull(signer);
+
+        var responses = ResponsesById(document);
+        var w = new Writer()
+            .Add("scheme", Scheme)
+            .Add("role", "filler")
+            .Add("templateId", document.Metadata.TemplateId)
+            .Add("templateVersion", document.Metadata.TemplateVersion);
+
+        // Deterministic regardless of the order fields are listed in the signature.
+        foreach (var id in fields.Distinct(StringComparer.Ordinal).OrderBy(x => x, StringComparer.Ordinal))
+        {
+            w.Add("field." + id, responses.GetValueOrDefault(id, string.Empty));
+        }
+
+        return w
+            .Add("signer.name", signer.Name)
+            .Add("signer.id", signer.Identifier)
+            .Add("signer.key", signer.PublicKey)
+            .Add("signedAt", signedAt)
+            .ToBytes();
+    }
+
+    /// <summary>
+    /// The canonical bytes of the form definition: title/template ids and the
+    /// ordered section/prompt structure with labels, hints, and table layout —
+    /// but <em>not</em> responses, response metadata, or the signatures array.
+    /// </summary>
+    public static byte[] FormDefinition(AprDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        var w = new Writer()
+            .Add("scheme", Scheme + "/formdef")
+            .Add("title", document.Metadata.Title)
+            .Add("templateId", document.Metadata.TemplateId)
+            .Add("templateVersion", document.Metadata.TemplateVersion);
+        foreach (var section in document.Sections)
+        {
+            AppendSection(w, section);
+        }
+        return w.ToBytes();
+    }
+
+    private static void AppendSection(Writer w, Section s)
+    {
+        w.Add("S.id", s.Id).Add("S.title", s.Title).Add("S.desc", s.Description);
+
+        if (s.TableLayout is { } table)
+        {
+            foreach (var c in table.Columns)
+            {
+                w.Add("S.col.id", c.Id).Add("S.col.label", c.Label).Add("S.col.type", c.Type);
+            }
+            foreach (var r in table.FixedRows ?? new List<FixedRow>())
+            {
+                w.Add("S.row.id", r.Id).Add("S.row.label", r.Label);
+            }
+        }
+
+        foreach (var p in s.Prompts)
+        {
+            AppendPrompt(w, p);
+        }
+        foreach (var child in s.Sections)
+        {
+            AppendSection(w, child);
+        }
+    }
+
+    private static void AppendPrompt(Writer w, Prompt p)
+    {
+        var h = p.Hints;
+        w.Add("P.id", p.Id)
+         .Add("P.label", p.Label)
+         .Add("P.type", h.ExpectedDataType)
+         .Add("P.placeholder", h.Placeholder)
+         .Add("P.help", h.HelpText)
+         .Add("P.suggested", string.Join("", h.SuggestedValues))
+         .Add("P.pattern", h.ValidationPattern)
+         .Add("P.exprHidden", h.ExprHidden)
+         .Add("P.exprValue", h.ExprValue)
+         .Add("P.exprExpected", h.ExprExpected)
+         .Add("P.exprValidation", h.ExprValidation)
+         .Add("P.exprReadOnly", h.ExprReadOnly);
+        // Intentionally excludes Response and ResponseMetadata: a publisher signs
+        // the blank form, so a filler entering responses does not break it.
+    }
+
+    private static Dictionary<string, string> ResponsesById(AprDocument document)
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var section in document.Sections)
+        {
+            CollectResponses(section, map);
+        }
+        return map;
+    }
+
+    private static void CollectResponses(Section s, Dictionary<string, string> into)
+    {
+        foreach (var p in s.Prompts)
+        {
+            if (!string.IsNullOrEmpty(p.Id))
+            {
+                into[p.Id] = p.Response;
+            }
+        }
+        foreach (var child in s.Sections)
+        {
+            CollectResponses(child, into);
+        }
+    }
+
+    private static string Sha256Hex(byte[] bytes) => Convert.ToHexString(SHA256.HashData(bytes));
+
+    /// <summary>
+    /// Builds the canonical payload: ordered <c>label=base64(utf8(value))</c> lines.
+    /// Base64-encoding the values makes the encoding unambiguous (no delimiter
+    /// injection) and the line order is fixed by the caller.
+    /// </summary>
+    private sealed class Writer
+    {
+        private readonly StringBuilder _sb = new();
+
+        public Writer Add(string label, string? value)
+        {
+            _sb.Append(label)
+               .Append('=')
+               .Append(Convert.ToBase64String(Encoding.UTF8.GetBytes(value ?? string.Empty)))
+               .Append('\n');
+            return this;
+        }
+
+        public byte[] ToBytes() => Encoding.UTF8.GetBytes(_sb.ToString());
+    }
+}

--- a/src/PromptResponse.Core/Signing/AprSigner.cs
+++ b/src/PromptResponse.Core/Signing/AprSigner.cs
@@ -1,0 +1,96 @@
+using System.Security.Cryptography;
+using PromptResponse.Core.Models;
+
+namespace PromptResponse.Core.Signing;
+
+/// <summary>
+/// Produces detached APR signatures (scheme <c>apr-sig-v1</c>, ECDSA P-256 +
+/// SHA-256). A publisher signs the template (binding the submission URL); a
+/// filler signs the responses in a scope. The returned <see cref="Signature"/>
+/// is added to <see cref="AprDocument.Signatures"/> by the caller.
+/// </summary>
+public static class AprSigner
+{
+    /// <summary>
+    /// Signs the form definition as the publisher, binding the submission URL so
+    /// it cannot be altered without invalidating the signature.
+    /// </summary>
+    public static Signature SignTemplate(
+        AprDocument document,
+        ECDsa privateKey,
+        string signerName,
+        string? identifier,
+        string? submissionUrl,
+        DateTime signedAtUtc,
+        string id = "publisher")
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(privateKey);
+
+        var signer = new Signer
+        {
+            Name = signerName,
+            Identifier = identifier,
+            PublicKey = SignatureKeys.ExportPublicKeyPem(privateKey),
+        };
+        var signedAt = signedAtUtc.ToUniversalTime().ToString("o");
+        var payload = AprCanonicalizer.PublisherPayload(document, signer, submissionUrl, signedAt);
+        var value = privateKey.SignData(payload, HashAlgorithmName.SHA256);
+
+        return new Signature
+        {
+            Id = id,
+            Role = SignatureRole.Publisher,
+            Signer = signer,
+            Scope = "template",
+            SubmissionUrl = submissionUrl,
+            Algorithm = "ecdsa-p256-sha256",
+            Canonicalization = AprCanonicalizer.Scheme,
+            SignedAt = signedAt,
+            Value = Convert.ToBase64String(value),
+        };
+    }
+
+    /// <summary>
+    /// Signs the responses of <paramref name="fields"/> as a filler. Multiple
+    /// fillers can each sign their own scope; editing a covered field invalidates
+    /// only the signatures that cover it.
+    /// </summary>
+    public static Signature SignFields(
+        AprDocument document,
+        ECDsa privateKey,
+        string signerName,
+        string? identifier,
+        IEnumerable<string> fields,
+        DateTime signedAtUtc,
+        string id)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(privateKey);
+        ArgumentNullException.ThrowIfNull(fields);
+
+        var signer = new Signer
+        {
+            Name = signerName,
+            Identifier = identifier,
+            PublicKey = SignatureKeys.ExportPublicKeyPem(privateKey),
+        };
+        var signedAt = signedAtUtc.ToUniversalTime().ToString("o");
+        var fieldList = fields.Distinct(StringComparer.Ordinal).ToList();
+        var payload = AprCanonicalizer.FillerPayload(document, fieldList, signer, signedAt);
+        var value = privateKey.SignData(payload, HashAlgorithmName.SHA256);
+
+        return new Signature
+        {
+            Id = id,
+            Role = SignatureRole.Filler,
+            Signer = signer,
+            Scope = "fields",
+            Fields = fieldList,
+            Algorithm = "ecdsa-p256-sha256",
+            Canonicalization = AprCanonicalizer.Scheme,
+            SignedAt = signedAt,
+            Value = Convert.ToBase64String(value),
+        };
+    }
+}

--- a/src/PromptResponse.Core/Signing/AprVerifier.cs
+++ b/src/PromptResponse.Core/Signing/AprVerifier.cs
@@ -1,0 +1,64 @@
+using System.Security.Cryptography;
+using PromptResponse.Core.Models;
+
+namespace PromptResponse.Core.Signing;
+
+/// <summary>The result of verifying one <see cref="Signature"/>.</summary>
+/// <param name="Id">The signature's id.</param>
+/// <param name="Role">Publisher or filler.</param>
+/// <param name="SignerName">The signer's claimed name.</param>
+/// <param name="IsValid">Whether the signature verifies against the current content.</param>
+/// <param name="Status">A human-readable explanation.</param>
+public sealed record SignatureVerification(string Id, SignatureRole Role, string SignerName, bool IsValid, string Status);
+
+/// <summary>
+/// Verifies detached APR signatures by recomputing the canonical payload over the
+/// document's <em>current</em> content and checking it against each signature's
+/// embedded public key. A valid result proves the covered content is unchanged
+/// since signing and that the holder of the matching private key signed it.
+/// </summary>
+/// <remarks>
+/// Trust is key-based: verification proves "the holder of this public key signed
+/// this content", not "this named identity". Binding a key to a real-world
+/// identity (e.g. matching a publisher's known/trusted key, or an X.509
+/// certificate chain) is an additive layer on top.
+/// </remarks>
+public static class AprVerifier
+{
+    /// <summary>Verifies every signature on the document.</summary>
+    public static IReadOnlyList<SignatureVerification> VerifyAll(AprDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        if (document.Signatures is null || document.Signatures.Count == 0)
+        {
+            return Array.Empty<SignatureVerification>();
+        }
+        return document.Signatures.Select(s => Verify(document, s)).ToList();
+    }
+
+    /// <summary>Verifies a single signature against the document's current content.</summary>
+    public static SignatureVerification Verify(AprDocument document, Signature signature)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(signature);
+
+        try
+        {
+            var payload = signature.Scope == "template"
+                ? AprCanonicalizer.PublisherPayload(document, signature.Signer, signature.SubmissionUrl, signature.SignedAt)
+                : AprCanonicalizer.FillerPayload(document, signature.Fields, signature.Signer, signature.SignedAt);
+
+            using var ec = ECDsa.Create();
+            ec.ImportFromPem(signature.Signer.PublicKey);
+            var ok = ec.VerifyData(payload, Convert.FromBase64String(signature.Value), HashAlgorithmName.SHA256);
+
+            return new SignatureVerification(
+                signature.Id, signature.Role, signature.Signer.Name, ok,
+                ok ? "valid" : "invalid — the covered content was altered, or the signature does not match the key");
+        }
+        catch (Exception ex)
+        {
+            return new SignatureVerification(signature.Id, signature.Role, signature.Signer.Name, false, "error: " + ex.Message);
+        }
+    }
+}

--- a/src/PromptResponse.Core/Signing/SignatureKeys.cs
+++ b/src/PromptResponse.Core/Signing/SignatureKeys.cs
@@ -1,0 +1,36 @@
+using System.Security.Cryptography;
+
+namespace PromptResponse.Core.Signing;
+
+/// <summary>
+/// Helpers for the ECDSA P-256 keys used by APR signing. Uses only the .NET
+/// built-in crypto (<see cref="ECDsa"/>) — no third-party dependency — with PEM
+/// import/export for portability.
+/// </summary>
+public static class SignatureKeys
+{
+    /// <summary>Generates a new ECDSA P-256 key pair.</summary>
+    public static ECDsa Generate() => ECDsa.Create(ECCurve.NamedCurves.nistP256);
+
+    /// <summary>Exports the private key as a PKCS#8 PEM block (keep this secret).</summary>
+    public static string ExportPrivateKeyPem(ECDsa key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        return key.ExportPkcs8PrivateKeyPem();
+    }
+
+    /// <summary>Exports the public key as a SubjectPublicKeyInfo PEM block.</summary>
+    public static string ExportPublicKeyPem(ECDsa key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        return key.ExportSubjectPublicKeyInfoPem();
+    }
+
+    /// <summary>Imports a key (private or public) from a PEM block.</summary>
+    public static ECDsa ImportFromPem(string pem)
+    {
+        var ec = ECDsa.Create();
+        ec.ImportFromPem(pem);
+        return ec;
+    }
+}

--- a/tests/PromptResponse.Core.Tests/Signing/AprSigningTests.cs
+++ b/tests/PromptResponse.Core.Tests/Signing/AprSigningTests.cs
@@ -1,0 +1,186 @@
+using AwesomeAssertions;
+using PromptResponse.Core.Models;
+using PromptResponse.Core.Serialization;
+using PromptResponse.Core.Signing;
+using Xunit;
+
+namespace PromptResponse.Core.Tests.Signing;
+
+/// <summary>
+/// Verifies the apr-sig-v1 signing protocol: publisher signs the template
+/// (binding the submission URL), fillers sign scoped responses, tampering is
+/// detected, scopes are isolated, and signatures survive JSON round-trips.
+/// </summary>
+public class AprSigningTests
+{
+    private static readonly DateTime At = new(2026, 6, 8, 12, 0, 0, DateTimeKind.Utc);
+
+    private static AprDocument Template() => new()
+    {
+        DocumentType = DocumentType.Template,
+        Metadata = new Metadata { Title = "Permit", TemplateId = "permit", TemplateVersion = "1.0" },
+        Sections =
+        [
+            new Section
+            {
+                Id = "s", Title = "Applicant",
+                Prompts =
+                [
+                    new Prompt { Id = "name", Label = "Name" },
+                    new Prompt { Id = "dob", Label = "Date of Birth" },
+                    new Prompt { Id = "notes", Label = "Notes" },
+                ],
+            },
+        ],
+    };
+
+    // ── Publisher signs the template ────────────────────────────────────────
+
+    [Fact]
+    public void Publisher_SignsTemplate_Verifies()
+    {
+        var doc = Template();
+        using var key = SignatureKeys.Generate();
+        doc.Signatures = [AprSigner.SignTemplate(doc, key, "Town of Bloomfield", "clerk@bloomfieldct.gov",
+            "https://bloomfieldct.gov/forms/permit/submit", At)];
+
+        var result = AprVerifier.VerifyAll(doc).Single();
+
+        result.IsValid.Should().BeTrue();
+        result.Role.Should().Be(SignatureRole.Publisher);
+        result.SignerName.Should().Be("Town of Bloomfield");
+    }
+
+    [Fact]
+    public void Publisher_DetectsFormDefinitionTampering()
+    {
+        var doc = Template();
+        using var key = SignatureKeys.Generate();
+        doc.Signatures = [AprSigner.SignTemplate(doc, key, "Pub", null, "https://x/submit", At)];
+
+        doc.Sections[0].Prompts[0].Label = "Full Name"; // alter the form definition
+
+        AprVerifier.Verify(doc, doc.Signatures[0]).IsValid
+            .Should().BeFalse("changing a label changes the signed form definition");
+    }
+
+    [Fact]
+    public void Publisher_Signature_BindsSubmissionUrl()
+    {
+        var doc = Template();
+        using var key = SignatureKeys.Generate();
+        doc.Signatures = [AprSigner.SignTemplate(doc, key, "Pub", null, "https://gov/submit", At)];
+
+        doc.Signatures[0].SubmissionUrl = "https://evil/submit"; // redirect attempt
+
+        AprVerifier.Verify(doc, doc.Signatures[0]).IsValid
+            .Should().BeFalse("the submission URL is bound into the publisher signature");
+    }
+
+    [Fact]
+    public void Publisher_Signature_SurvivesFilling()
+    {
+        var doc = Template();
+        using var key = SignatureKeys.Generate();
+        doc.Signatures = [AprSigner.SignTemplate(doc, key, "Pub", null, "https://gov/submit", At)];
+
+        doc.Sections[0].Prompts[0].Response = "Ada Lovelace"; // a filler enters a response
+
+        AprVerifier.Verify(doc, doc.Signatures[0]).IsValid
+            .Should().BeTrue("responses are not part of the signed form definition");
+    }
+
+    // ── Filler signs scoped responses ───────────────────────────────────────
+
+    [Fact]
+    public void Filler_SignsScope_Verifies()
+    {
+        var doc = Template();
+        doc.Sections[0].Prompts[0].Response = "Ada";
+        doc.Sections[0].Prompts[1].Response = "1815-12-10";
+        using var key = SignatureKeys.Generate();
+        doc.Signatures = [AprSigner.SignFields(doc, key, "Ada", null, ["name", "dob"], At, "sig1")];
+
+        AprVerifier.Verify(doc, doc.Signatures[0]).IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Filler_DetectsTamperWithinScope()
+    {
+        var doc = Template();
+        doc.Sections[0].Prompts[0].Response = "Ada";
+        using var key = SignatureKeys.Generate();
+        doc.Signatures = [AprSigner.SignFields(doc, key, "Ada", null, ["name"], At, "sig1")];
+
+        doc.Sections[0].Prompts[0].Response = "Mallory"; // alter a covered response
+
+        AprVerifier.Verify(doc, doc.Signatures[0]).IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Filler_ScopeIsolation_OutOfScopeEditDoesNotInvalidate()
+    {
+        var doc = Template();
+        doc.Sections[0].Prompts[0].Response = "Ada";
+        using var key = SignatureKeys.Generate();
+        doc.Signatures = [AprSigner.SignFields(doc, key, "Ada", null, ["name"], At, "sig1")];
+
+        doc.Sections[0].Prompts[2].Response = "edited later"; // "notes" is out of scope
+
+        AprVerifier.Verify(doc, doc.Signatures[0]).IsValid
+            .Should().BeTrue("editing a field outside the signature's scope must not invalidate it");
+    }
+
+    [Fact]
+    public void MultipleFillers_EachSignTheirParts_Independently()
+    {
+        var doc = Template();
+        doc.Sections[0].Prompts[0].Response = "Ada";   // signed by filler 1
+        doc.Sections[0].Prompts[1].Response = "1815";  // signed by filler 2
+        using var k1 = SignatureKeys.Generate();
+        using var k2 = SignatureKeys.Generate();
+        doc.Signatures =
+        [
+            AprSigner.SignFields(doc, k1, "Ada", null, ["name"], At, "sig-ada"),
+            AprSigner.SignFields(doc, k2, "Reviewer", null, ["dob"], At, "sig-rev"),
+        ];
+
+        AprVerifier.VerifyAll(doc).Should().OnlyContain(r => r.IsValid);
+
+        doc.Sections[0].Prompts[0].Response = "Mallory"; // tamper only filler 1's field
+
+        var after = AprVerifier.VerifyAll(doc);
+        after.Single(r => r.Id == "sig-ada").IsValid.Should().BeFalse();
+        after.Single(r => r.Id == "sig-rev").IsValid.Should().BeTrue("the reviewer's scope is untouched");
+    }
+
+    // ── Persistence ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Signatures_SurviveJsonRoundTrip()
+    {
+        var doc = Template();
+        doc.Sections[0].Prompts[0].Response = "Ada";
+        using var pubKey = SignatureKeys.Generate();
+        using var fillKey = SignatureKeys.Generate();
+        doc.Signatures =
+        [
+            AprSigner.SignTemplate(doc, pubKey, "Pub", null, "https://gov/submit", At),
+            AprSigner.SignFields(doc, fillKey, "Ada", null, ["name"], At, "sig1"),
+        ];
+
+        var serializer = new AprJsonSerializer();
+        var reloaded = serializer.Deserialize(serializer.Serialize(doc));
+
+        AprVerifier.VerifyAll(reloaded).Should().OnlyContain(r => r.IsValid,
+            "signatures must verify after a serialize/deserialize cycle");
+        reloaded.Signatures.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void UnsignedDocument_HasNoSignaturesField()
+    {
+        var json = new AprJsonSerializer().Serialize(Template());
+        json.Should().NotContain("signatures", "an unsigned document should not carry a signatures field");
+    }
+}


### PR DESCRIPTION
The cryptographic foundation for the signature model you specified — built dependency-free on .NET's built-in ECDSA P-256.

**What it does**
- **Publisher signs the template** and the signature **binds the submission URL** — an attacker can't swap the URL to redirect submissions without breaking the signature.
- **Fillers sign the responses in their scope**; **multiple signers** can each cover the parts they filled.
- **Tamper-evident** (editing a covered field invalidates its signatures), **scope-isolated** (out-of-scope edits don't), and signatures **survive JSON round-trips**.

**Design** (`apr-sig-v1`): detached signatures in a `signatures[]` array; a versioned, language-portable canonical payload (ordered `label=base64(value)` lines, not whole-doc JSON canonicalization) so other SDKs can reproduce it. Publisher payload = form-definition digest + bound URL; filler payload = sorted `(fieldId, response)` in scope. Pure data + pure-computation verification — consistent with 'no code execution, safe to open untrusted'. Trust is key-based now; X.509/PKI is additive.

New `PromptResponse.Core.Signing` + `Signature`/`Signer` model + `metadata.publisher`/`submissionUrl`. **10 protocol tests**; Core 496 → 506; unsigned files are unchanged (no `signatures` field).

**Follows:** CLI (`keygen`/`sign`/`verify`), desktop sign/verify UI, and rendering signature status into PDF/HTML. (#73)

🤖 Generated with [Claude Code](https://claude.com/claude-code)