### PR TITLE
feat: signing CLI — keygen / sign / verify (end-to-end)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Signing CLI** (Path A) — the signature flow end-to-end from the command line:
+  `apr keygen` (self-signed signing cert → `.pfx` + a public `.cer` to pin),
+  `apr sign <file> --publisher --cert=… --url=…` (publisher signs the template +
+  binds the submit URL), `apr sign <file> --fields=id1,id2 --cert=…` (filler signs
+  their responses), and `apr verify <file> [--trust=anchor.cer]` (reports per
+  signature: content-valid + trusted / self-signed / untrusted / invalid; exits
+  non-zero if any signed content was altered). Works with CA-issued or self-signed
+  `.pfx` certs.
+
 - **Verifiable signatures — foundation** (Path A) — `apr-sig-v2`: industry-standard
   **CMS / PKCS#7 `SignedData`** (RFC 5652) over APR's canonical *content*, signed by
   **X.509 certificates** (RFC 5280) with **FIPS-approved algorithms** (ECDSA P-256 +

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -1,0 +1,82 @@
+# Signing APR forms
+
+APR documents can carry **verifiable digital signatures** using industry-standard
+**CMS / PKCS#7** over X.509 certificates (the same cryptographic standards PDF and
+government PKI use). Unlike PDF signing, APR signs the form's **content/meaning**,
+not the rendered bytes — so a signature survives re-serialization and re-export,
+is **field-scoped**, and supports **multiple signers** who each sign the part they
+filled.
+
+Two signature roles:
+- **Publisher** signs the *template* (the form definition) and **binds the
+  submission URL**, so it can't be redirected without invalidating the signature.
+- **Filler** signs the *responses* in a chosen scope. Multiple fillers can each
+  sign their own fields; editing a covered field invalidates only the signatures
+  that cover it.
+
+Trust works two ways, matching real deployments:
+- **CA-issued certificate** (Federal PKI / PIV-CAC / org CA / eIDAS) — trusted by
+  chaining to a configured root.
+- **Self-signed certificate** — trusted by **pinning** its public cert.
+
+> Crypto: ECDSA P-256 + SHA-256 (FIPS-approved), built-in .NET. This is the
+> CAdES-BES tier; trusted timestamps (RFC 3161) and long-term validation are
+> planned additive layers. See [issue #73](https://github.com/marctjones/promptresponse/issues/73).
+
+## End-to-end (CLI)
+
+```bash
+# 1) Publisher: make a signing certificate (or use a CA-issued .pfx / PIV card)
+apr keygen --name="Town of Bloomfield" --output=publisher.pfx --cert-out=publisher.cer
+
+# 2) Publisher signs the template and binds the submission URL
+apr sign permit.aprt --publisher --cert=publisher.pfx \
+    --url="https://bloomfieldct.gov/permit/submit"
+
+# 3) A person fills the form, then signs the fields they completed
+apr keygen --name="Ada Lovelace" --output=ada.pfx
+apr sign permit.aprf --fields=applicant_name,dob --cert=ada.pfx --id=ada
+
+# 4) Verify — pin the publisher's public cert as a trust anchor
+apr verify permit.aprf --trust=publisher.cer
+```
+
+`verify` prints, per signature, whether the covered content is intact and how far
+the certificate is trusted (`trusted` / `self-signed` / `untrusted` / `INVALID`),
+and exits non-zero if any signed content was altered.
+
+## Commands
+
+### `keygen`
+```
+apr keygen --name="<signer>" --output=<file.pfx> [--password=<pw>] [--cert-out=<file.cer>] [--years=<n>]
+```
+Generates a self-signed ECDSA P-256 signing certificate. Share the `.cer` so
+others can pin it. (For real PKI, skip this and use a CA-issued `.pfx` or a smart
+card.)
+
+### `sign`
+```
+apr sign <file> --publisher --cert=<file.pfx> [--password=<pw>] --url=<submitUrl> [--id=<id>] [--output=<file>]
+apr sign <file> --fields=<id1,id2,...> --cert=<file.pfx> [--password=<pw>] [--id=<id>] [--output=<file>]
+```
+Appends a signature to the document. Publisher signing also records
+`metadata.submissionUrl` (and binds it into the signature). Writes in place unless
+`--output` is given.
+
+### `verify`
+```
+apr verify <file> [--trust=<anchor1.cer,anchor2.cer>] [--check-revocation]
+```
+Verifies all signatures against the document's current content. `--trust` supplies
+CA roots and/or pinned self-signed certs; `--check-revocation` enables OCSP/CRL
+(needs network). Exit code is non-zero if any signature is invalid.
+
+## Library
+
+```csharp
+using PromptResponse.Core.Signing;
+var sig = AprSigner.SignTemplate(doc, cert, submissionUrl, DateTime.UtcNow);
+doc.Signatures = [sig];
+var results = AprVerifier.VerifyAll(doc, new AprTrustOptions { TrustAnchors = [publisherCert] });
+```

--- a/src/PromptResponse.Cli/Commands/KeygenCommand.cs
+++ b/src/PromptResponse.Cli/Commands/KeygenCommand.cs
@@ -1,0 +1,60 @@
+using System.Security.Cryptography.X509Certificates;
+using PromptResponse.Core.Signing;
+
+namespace PromptResponse.Cli.Commands;
+
+/// <summary>
+/// Generates a self-signed ECDSA P-256 signing certificate (PKCS#12 / .pfx), for
+/// organizations or people who don't have a CA-issued certificate. Distribute the
+/// public <c>.cer</c> so others can pin it as a trust anchor.
+/// </summary>
+public class KeygenCommand : ICommand
+{
+    public Task<int> ExecuteAsync(string[] args)
+    {
+        var name = GetArgValue(args, "--name");
+        var output = GetArgValue(args, "--output");
+        var password = GetArgValue(args, "--password");
+        var certOut = GetArgValue(args, "--cert-out");
+        var years = int.TryParse(GetArgValue(args, "--years"), out var y) ? y : 2;
+
+        if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(output))
+        {
+            Console.Error.WriteLine("Error: --name and --output are required");
+            Console.Error.WriteLine("Usage: apr keygen --name=\"<signer>\" --output=<file.pfx> [--password=<pw>] [--cert-out=<file.cer>] [--years=<n>]");
+            return Task.FromResult(1);
+        }
+
+        try
+        {
+            var notBefore = DateTimeOffset.UtcNow.AddMinutes(-5);
+            var notAfter = notBefore.AddYears(years);
+            using var cert = SignatureCertificates.CreateSelfSigned(name!, notBefore, notAfter);
+
+            File.WriteAllBytes(output!, cert.Export(X509ContentType.Pkcs12, password));
+            Console.WriteLine($"Wrote signing certificate (private key): {output}");
+
+            if (!string.IsNullOrWhiteSpace(certOut))
+            {
+                File.WriteAllBytes(certOut!, cert.Export(X509ContentType.Cert));
+                Console.WriteLine($"Wrote public certificate (share to pin): {certOut}");
+            }
+
+            Console.WriteLine($"  Subject:    {cert.Subject}");
+            Console.WriteLine($"  Thumbprint: {SignatureCertificates.Sha256Thumbprint(cert)}");
+            Console.WriteLine($"  Valid:      {notBefore:yyyy-MM-dd} → {notAfter:yyyy-MM-dd}");
+            return Task.FromResult(0);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error: failed to generate certificate: {ex.Message}");
+            return Task.FromResult(1);
+        }
+    }
+
+    private static string? GetArgValue(string[] args, string prefix)
+    {
+        var arg = args.FirstOrDefault(a => a.StartsWith(prefix + "="));
+        return arg?.Substring(prefix.Length + 1);
+    }
+}

--- a/src/PromptResponse.Cli/Commands/SignCommand.cs
+++ b/src/PromptResponse.Cli/Commands/SignCommand.cs
@@ -1,0 +1,95 @@
+using System.Security.Cryptography.X509Certificates;
+using PromptResponse.Core.Models;
+using PromptResponse.Core.Serialization;
+using PromptResponse.Core.Signing;
+
+namespace PromptResponse.Cli.Commands;
+
+/// <summary>
+/// Signs an APR document with an X.509 certificate (PKCS#12 / .pfx). A publisher
+/// signs the template and binds the submission URL; a filler signs the responses
+/// of specific fields.
+/// </summary>
+public class SignCommand : ICommand
+{
+    private readonly IAprSerializer _serializer;
+
+    public SignCommand(IAprSerializer serializer) => _serializer = serializer;
+
+    public async Task<int> ExecuteAsync(string[] args)
+    {
+        var filePath = args.FirstOrDefault(a => !a.StartsWith("--"));
+        var certPath = GetArgValue(args, "--cert");
+        var password = GetArgValue(args, "--password");
+        var publisher = args.Contains("--publisher");
+        var fieldsArg = GetArgValue(args, "--fields");
+        var url = GetArgValue(args, "--url");
+        var id = GetArgValue(args, "--id");
+        var output = GetArgValue(args, "--output");
+
+        if (string.IsNullOrEmpty(filePath) || string.IsNullOrEmpty(certPath))
+        {
+            Console.Error.WriteLine("Error: an APR file and --cert are required");
+            Console.Error.WriteLine("Usage:");
+            Console.Error.WriteLine("  apr sign <file> --publisher --cert=<file.pfx> [--password=<pw>] --url=<submitUrl> [--id=<id>] [--output=<file>]");
+            Console.Error.WriteLine("  apr sign <file> --fields=<id1,id2,...> --cert=<file.pfx> [--password=<pw>] [--id=<id>] [--output=<file>]");
+            return 1;
+        }
+        if (!File.Exists(filePath)) { Console.Error.WriteLine($"Error: File not found: {filePath}"); return 1; }
+        if (!File.Exists(certPath)) { Console.Error.WriteLine($"Error: Certificate not found: {certPath}"); return 1; }
+        if (!publisher && string.IsNullOrEmpty(fieldsArg))
+        {
+            Console.Error.WriteLine("Error: specify --publisher, or --fields=<id1,id2,...> to sign responses");
+            return 1;
+        }
+
+        try
+        {
+            var document = _serializer.Deserialize(await File.ReadAllTextAsync(filePath));
+            using var cert = SignatureCertificates.LoadPfx(certPath!, password);
+            if (!cert.HasPrivateKey)
+            {
+                Console.Error.WriteLine("Error: the certificate has no private key (need a .pfx that includes the key)");
+                return 1;
+            }
+
+            document.Signatures ??= new List<Signature>();
+            Signature signature;
+
+            if (publisher)
+            {
+                signature = AprSigner.SignTemplate(document, cert, url, DateTime.UtcNow, id ?? "publisher");
+                document.Metadata.Publisher ??= signature.Signer.Name;
+                if (!string.IsNullOrEmpty(url)) document.Metadata.SubmissionUrl = url;
+            }
+            else
+            {
+                var fields = fieldsArg!.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                signature = AprSigner.SignFields(document, cert, fields, DateTime.UtcNow, id ?? $"sig{document.Signatures.Count + 1}");
+            }
+
+            document.Signatures.Add(signature);
+
+            var outPath = string.IsNullOrEmpty(output) ? filePath! : output!;
+            await File.WriteAllTextAsync(outPath, _serializer.Serialize(document));
+
+            Console.WriteLine($"Signed as {signature.Role}: {signature.Signer.Name}");
+            Console.WriteLine($"  Scope:      {(signature.Scope == "template" ? "template (form definition)" : string.Join(", ", signature.Fields))}");
+            if (signature.SubmissionUrl is { Length: > 0 }) Console.WriteLine($"  Submit URL: {signature.SubmissionUrl} (bound)");
+            Console.WriteLine($"  Thumbprint: {signature.Signer.Thumbprint}");
+            Console.WriteLine($"Wrote: {outPath}");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error: failed to sign: {ex.Message}");
+            return 1;
+        }
+    }
+
+    private static string? GetArgValue(string[] args, string prefix)
+    {
+        var arg = args.FirstOrDefault(a => a.StartsWith(prefix + "="));
+        return arg?.Substring(prefix.Length + 1);
+    }
+}

--- a/src/PromptResponse.Cli/Commands/VerifyCommand.cs
+++ b/src/PromptResponse.Cli/Commands/VerifyCommand.cs
@@ -1,0 +1,86 @@
+using System.Security.Cryptography.X509Certificates;
+using PromptResponse.Core.Serialization;
+using PromptResponse.Core.Signing;
+
+namespace PromptResponse.Cli.Commands;
+
+/// <summary>
+/// Verifies the signatures on an APR document: whether each one's covered content
+/// is unchanged, and how far the signer's certificate is trusted (chains to a
+/// configured trust anchor, or is a pinned self-signed cert).
+/// </summary>
+public class VerifyCommand : ICommand
+{
+    private readonly IAprSerializer _serializer;
+
+    public VerifyCommand(IAprSerializer serializer) => _serializer = serializer;
+
+    public async Task<int> ExecuteAsync(string[] args)
+    {
+        var filePath = args.FirstOrDefault(a => !a.StartsWith("--"));
+        var trustArg = GetArgValue(args, "--trust");
+        var checkRevocation = args.Contains("--check-revocation");
+
+        if (string.IsNullOrEmpty(filePath))
+        {
+            Console.Error.WriteLine("Error: File path required");
+            Console.Error.WriteLine("Usage: apr verify <file> [--trust=<anchor1.cer,anchor2.cer>] [--check-revocation]");
+            return 1;
+        }
+        if (!File.Exists(filePath)) { Console.Error.WriteLine($"Error: File not found: {filePath}"); return 1; }
+
+        try
+        {
+            var document = _serializer.Deserialize(await File.ReadAllTextAsync(filePath));
+
+            List<X509Certificate2>? anchors = null;
+            if (!string.IsNullOrEmpty(trustArg))
+            {
+                anchors = new List<X509Certificate2>();
+                foreach (var p in trustArg.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                {
+                    if (!File.Exists(p)) { Console.Error.WriteLine($"Error: trust anchor not found: {p}"); return 1; }
+                    anchors.Add(SignatureCertificates.LoadCertificate(p));
+                }
+            }
+
+            var options = new AprTrustOptions { TrustAnchors = anchors, CheckRevocation = checkRevocation };
+            var results = AprVerifier.VerifyAll(document, options);
+
+            if (results.Count == 0)
+            {
+                Console.WriteLine("No signatures on this document.");
+                return 0;
+            }
+
+            Console.WriteLine($"Signatures: {results.Count}");
+            foreach (var r in results)
+            {
+                var mark = !r.ContentValid ? "✗ INVALID"
+                    : r.Trust == SignatureTrust.Trusted ? "✓ trusted"
+                    : r.Trust == SignatureTrust.SelfSigned ? "~ self-signed"
+                    : "! untrusted";
+                Console.WriteLine($"  [{r.Role}] {r.Id}: {mark}");
+                Console.WriteLine($"      signer: {r.SignerName}");
+                Console.WriteLine($"      status: {r.Status}");
+            }
+
+            var anyInvalid = results.Any(r => !r.ContentValid);
+            Console.WriteLine(anyInvalid
+                ? "Result: ✗ one or more signatures are INVALID (content was altered)."
+                : "Result: ✓ all signatures verify over the current content.");
+            return anyInvalid ? 1 : 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error: failed to verify: {ex.Message}");
+            return 1;
+        }
+    }
+
+    private static string? GetArgValue(string[] args, string prefix)
+    {
+        var arg = args.FirstOrDefault(a => a.StartsWith(prefix + "="));
+        return arg?.Substring(prefix.Length + 1);
+    }
+}

--- a/src/PromptResponse.Cli/Program.cs
+++ b/src/PromptResponse.Cli/Program.cs
@@ -41,6 +41,9 @@ class Program
                 "diff" => await serviceProvider.GetRequiredService<DiffCommand>().ExecuteAsync(commandArgs),
                 "export" => await serviceProvider.GetRequiredService<ExportCommand>().ExecuteAsync(commandArgs),
                 "import" => await serviceProvider.GetRequiredService<ImportCommand>().ExecuteAsync(commandArgs),
+                "keygen" => await serviceProvider.GetRequiredService<KeygenCommand>().ExecuteAsync(commandArgs),
+                "sign" => await serviceProvider.GetRequiredService<SignCommand>().ExecuteAsync(commandArgs),
+                "verify" => await serviceProvider.GetRequiredService<VerifyCommand>().ExecuteAsync(commandArgs),
                 "help" or "--help" or "-h" => ShowHelp(),
                 "version" or "--version" or "-v" => ShowVersion(),
                 _ => ShowUnknownCommand(command)
@@ -79,6 +82,9 @@ class Program
         services.AddTransient<DiffCommand>();
         services.AddTransient<ExportCommand>();
         services.AddTransient<ImportCommand>();
+        services.AddTransient<KeygenCommand>();
+        services.AddTransient<SignCommand>();
+        services.AddTransient<VerifyCommand>();
     }
 
     private static int ShowHelp()
@@ -95,6 +101,10 @@ class Program
         Console.WriteLine("  stats <file> [--json]          Show detailed statistics");
         Console.WriteLine("  diff <file1> <file2>           Compare two APR files");
         Console.WriteLine("  export <file> [options]        Export responses to various formats");
+        Console.WriteLine("  import <file.pdf> [options]    Import a fillable PDF into an APR template");
+        Console.WriteLine("  keygen [options]               Generate a self-signed signing certificate (.pfx)");
+        Console.WriteLine("  sign <file> [options]          Sign a document (publisher or filler) with an X.509 cert");
+        Console.WriteLine("  verify <file> [options]        Verify signatures and report trust");
         Console.WriteLine("  help                           Show this help message");
         Console.WriteLine("  version                        Show version information");
         Console.WriteLine();

--- a/src/PromptResponse.Cli/README.md
+++ b/src/PromptResponse.Cli/README.md
@@ -175,6 +175,28 @@ recommendation. Flat/scanned PDFs (no form fields) report an error — for those
 plus Word/OpenDocument/images, use the `document-to-apr` skill. See
 [docs/IMPORT.md](../../docs/IMPORT.md).
 
+### keygen / sign / verify
+
+Digital signatures over APR content (industry-standard CMS/PKCS#7 + X.509).
+
+```bash
+# generate a self-signed signing cert (or use a CA-issued .pfx / PIV card)
+apr keygen --name="Town of Bloomfield" --output=publisher.pfx --cert-out=publisher.cer
+
+# publisher signs the template and binds the submission URL
+apr sign permit.aprt --publisher --cert=publisher.pfx --url="https://gov/permit/submit"
+
+# a filler signs the responses they completed
+apr sign permit.aprf --fields=applicant_name,dob --cert=ada.pfx --id=ada
+
+# verify, pinning the publisher's public cert as a trust anchor
+apr verify permit.aprf --trust=publisher.cer
+```
+
+`verify` reports each signature as `trusted` / `self-signed` / `untrusted` /
+`INVALID` and exits non-zero if signed content was altered. Full guide:
+[docs/SIGNING.md](../../docs/SIGNING.md).
+
 ### help
 
 Shows usage information.

--- a/src/PromptResponse.Core/Signing/SignatureCertificates.cs
+++ b/src/PromptResponse.Core/Signing/SignatureCertificates.cs
@@ -63,6 +63,10 @@ public static class SignatureCertificates
     public static X509Certificate2 LoadPfx(string path, string? password = null) =>
         X509CertificateLoader.LoadPkcs12FromFile(path, password);
 
+    /// <summary>Loads a public certificate (no private key) from a DER/PEM .cer/.crt file — used as a trust anchor.</summary>
+    public static X509Certificate2 LoadCertificate(string path) =>
+        X509CertificateLoader.LoadCertificateFromFile(path);
+
     /// <summary>The certificate's SHA-256 thumbprint as an uppercase hex string (for pinning).</summary>
     public static string Sha256Thumbprint(X509Certificate2 cert) =>
         Convert.ToHexString(SHA256.HashData(cert.RawData));

--- a/tests/PromptResponse.Cli.Tests/Commands/SigningCommandsTests.cs
+++ b/tests/PromptResponse.Cli.Tests/Commands/SigningCommandsTests.cs
@@ -1,0 +1,118 @@
+using AwesomeAssertions;
+using PromptResponse.Cli.Commands;
+using PromptResponse.Core.Models;
+using PromptResponse.Core.Serialization;
+using Xunit;
+
+namespace PromptResponse.Cli.Tests.Commands;
+
+/// <summary>
+/// End-to-end tests for the signing CLI: keygen → sign (publisher + filler) →
+/// verify, including trust reporting and tamper detection.
+/// </summary>
+public class SigningCommandsTests : IDisposable
+{
+    private readonly AprJsonSerializer _serializer = new();
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), $"apr-sign-{Guid.NewGuid():N}");
+
+    public SigningCommandsTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, true); } catch { /* best effort */ }
+    }
+
+    private string Path_(string name) => System.IO.Path.Combine(_dir, name);
+
+    private async Task WriteTemplate(string path)
+    {
+        var doc = new AprDocument
+        {
+            DocumentType = DocumentType.Template,
+            Metadata = new Metadata { Title = "Permit", TemplateId = "permit", TemplateVersion = "1.0" },
+            Sections =
+            [
+                new Section { Id = "s", Title = "Applicant", Prompts =
+                [
+                    new Prompt { Id = "name", Label = "Name" },
+                    new Prompt { Id = "email", Label = "Email" },
+                ]},
+            ],
+        };
+        await File.WriteAllTextAsync(path, _serializer.Serialize(doc));
+    }
+
+    [Fact]
+    public async Task Keygen_WritesPfxAndPublicCert()
+    {
+        var pfx = Path_("k.pfx");
+        var cer = Path_("k.cer");
+
+        var exit = await new KeygenCommand().ExecuteAsync(new[] { "--name=Town of Bloomfield", $"--output={pfx}", $"--cert-out={cer}" });
+
+        exit.Should().Be(0);
+        File.Exists(pfx).Should().BeTrue();
+        File.Exists(cer).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task PublisherSign_ThenVerify_PinnedIsTrusted()
+    {
+        var form = Path_("form.aprt");
+        var pfx = Path_("pub.pfx");
+        var cer = Path_("pub.cer");
+        await WriteTemplate(form);
+        await new KeygenCommand().ExecuteAsync(new[] { "--name=Town of Bloomfield", $"--output={pfx}", $"--cert-out={cer}" });
+
+        var sign = await new SignCommand(_serializer).ExecuteAsync(
+            new[] { form, "--publisher", $"--cert={pfx}", "--url=https://gov/submit" });
+        sign.Should().Be(0);
+
+        // The signature + bound URL landed in the file.
+        var signed = _serializer.Deserialize(await File.ReadAllTextAsync(form));
+        signed.Signatures.Should().ContainSingle();
+        signed.Metadata.SubmissionUrl.Should().Be("https://gov/submit");
+
+        var verify = await new VerifyCommand(_serializer).ExecuteAsync(new[] { form, $"--trust={cer}" });
+        verify.Should().Be(0, "a pinned publisher signature over unaltered content verifies");
+    }
+
+    [Fact]
+    public async Task FillerSign_ThenTamper_VerifyFails()
+    {
+        var form = Path_("form.aprt");
+        var pfx = Path_("ada.pfx");
+        await WriteTemplate(form);
+        await new KeygenCommand().ExecuteAsync(new[] { "--name=Ada", $"--output={pfx}" });
+
+        // Put a response in, then sign it.
+        var doc = _serializer.Deserialize(await File.ReadAllTextAsync(form));
+        doc.Sections[0].Prompts[0].Response = "Ada Lovelace";
+        await File.WriteAllTextAsync(form, _serializer.Serialize(doc));
+        (await new SignCommand(_serializer).ExecuteAsync(new[] { form, "--fields=name", $"--cert={pfx}", "--id=ada" }))
+            .Should().Be(0);
+
+        (await new VerifyCommand(_serializer).ExecuteAsync(new[] { form }))
+            .Should().Be(0, "the unaltered signed content verifies");
+
+        // Tamper with the signed response.
+        var tampered = _serializer.Deserialize(await File.ReadAllTextAsync(form));
+        tampered.Sections[0].Prompts[0].Response = "Mallory";
+        await File.WriteAllTextAsync(form, _serializer.Serialize(tampered));
+
+        (await new VerifyCommand(_serializer).ExecuteAsync(new[] { form }))
+            .Should().Be(1, "verify must fail (exit 1) when signed content was altered");
+    }
+
+    [Fact]
+    public async Task Sign_WithoutPublisherOrFields_IsAnError()
+    {
+        var form = Path_("form.aprt");
+        var pfx = Path_("k.pfx");
+        await WriteTemplate(form);
+        await new KeygenCommand().ExecuteAsync(new[] { "--name=X", $"--output={pfx}" });
+
+        (await new SignCommand(_serializer).ExecuteAsync(new[] { form, $"--cert={pfx}" }))
+            .Should().Be(1);
+    }
+}


### PR DESCRIPTION
The whole signature flow from the command line.

```bash
apr keygen --name="Town of Bloomfield" --output=publisher.pfx --cert-out=publisher.cer
apr sign permit.aprt --publisher --cert=publisher.pfx --url="https://gov/permit/submit"
apr sign permit.aprf --fields=applicant_name,dob --cert=ada.pfx --id=ada
apr verify permit.aprf --trust=publisher.cer
```

- **keygen** — self-signed ECDSA P-256 cert (.pfx + public .cer to pin); or use a CA-issued .pfx / PIV card.
- **sign --publisher --url** — publisher signs the template + **binds the submission URL** (records `metadata.submissionUrl`).
- **sign --fields** — filler signs the responses they completed.
- **verify [--trust=…]** — per-signature **content-valid + trust** (`trusted`/`self-signed`/`untrusted`/`INVALID`); **exit 1** if signed content was altered.

Verified end-to-end: publisher trusted when its cert is pinned, filler self-signed when not, and tampering a filler-signed field → INVALID while the publisher signature stays trusted (correct scope). **4 CLI tests; CLI 106 → 110.** New `docs/SIGNING.md` + CLI README. (#73)

Next: desktop sign/verify UI + rendering signature status into PDF/HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)