### PR TITLE
feat: desktop signatures verify/trust panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Desktop signatures panel** (Path A) — opening a signed form now shows a
+  **Signatures** panel in the right rail: a one-line summary ("N signature(s) —
+  all verify" / "… one or more INVALID") and a row per signature with role,
+  signer, scope, and trust status, plus a **Re-verify** button. Verifies on load
+  (default trust; self-signed certs show as such until pinning/CA trust is wired
+  into the GUI). Accessible (AutomationProperties throughout). In-GUI *signing*
+  actions are a follow-up. (#73)
+
 - **Signature status in exports** (Path A) — a signed document's PDF, HTML, and
   plain-text output now ends with a **Signatures** section listing each signature's
   role, signer, scope, and verification (`[verified]`/`[INVALID]` + trust level), so

--- a/src/PromptResponse.Desktop/ViewModels/MainShellViewModel.cs
+++ b/src/PromptResponse.Desktop/ViewModels/MainShellViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using PromptResponse.Core.Expressions;
 using PromptResponse.Core.Models;
+using PromptResponse.Core.Signing;
 using PromptResponse.Core.Rendering;
 using PromptResponse.Core.Validation;
 using PromptResponse.Desktop.Profiles;
@@ -35,6 +36,7 @@ public sealed partial class MainShellViewModel : ObservableObject, IDisposable
     private readonly ObservableCollection<PromptViewModelBase> _promptViewModels = new();
     private readonly ObservableCollection<SectionViewModel> _sections = new();
     private readonly ObservableCollection<AdvisoryItem> _advisories = new();
+    private readonly ObservableCollection<SignatureStatusItem> _signatures = new();
 
     public MainShellViewModel(
         IFileService fileService,
@@ -421,6 +423,50 @@ public sealed partial class MainShellViewModel : ObservableObject, IDisposable
             FocusPromptRequested?.Invoke(promptId);
         }
     }
+
+    // ── signatures (verify / trust status) ───────────────────────────────────
+
+    /// <summary>The document's signatures with their verification + trust status.</summary>
+    public IReadOnlyList<SignatureStatusItem> Signatures => _signatures;
+
+    /// <summary>Whether the open document carries any signatures.</summary>
+    public bool HasSignatures => _signatures.Count > 0;
+
+    /// <summary>A one-line summary for the signatures panel.</summary>
+    public string SignatureSummary => _signatures.Count == 0
+        ? "Not signed"
+        : _signatures.Any(s => !s.ContentValid)
+            ? $"{_signatures.Count} signature(s) — one or more INVALID"
+            : $"{_signatures.Count} signature(s) — all verify";
+
+    /// <summary>
+    /// Re-verifies the document's signatures (default trust: certificates are
+    /// reported as trusted only if self-signed certs are pinned or CA certs chain
+    /// to a configured root — neither is wired in the GUI yet, so self-signed certs
+    /// show as "SelfSigned"). Cheap to call on load; not run on every keystroke.
+    /// </summary>
+    public void RefreshSignatures()
+    {
+        _signatures.Clear();
+        var doc = _session.CurrentDocument;
+        if (doc?.Signatures is { Count: > 0 } sigs)
+        {
+            var results = AprVerifier.VerifyAll(doc);
+            for (var i = 0; i < sigs.Count && i < results.Count; i++)
+            {
+                var r = results[i];
+                var scope = sigs[i].Scope == "template" ? "form definition" : string.Join(", ", sigs[i].Fields);
+                _signatures.Add(new SignatureStatusItem(r.Id, r.Role.ToString(), r.SignerName, scope, r.ContentValid, r.Trust.ToString(), r.Status));
+            }
+        }
+        OnPropertyChanged(nameof(Signatures));
+        OnPropertyChanged(nameof(HasSignatures));
+        OnPropertyChanged(nameof(SignatureSummary));
+    }
+
+    /// <summary>Re-verifies signatures on demand (e.g. after editing responses).</summary>
+    [RelayCommand]
+    public void RefreshSignaturesNow() => RefreshSignatures();
 
     /// <summary>
     /// Re-runs the advisory inspection over the current document. Per the vision,
@@ -938,6 +984,7 @@ public sealed partial class MainShellViewModel : ObservableObject, IDisposable
         OnPropertyChanged(nameof(Metadata));
         ToggleEditModeCommand.NotifyCanExecuteChanged();
         RefreshAdvisories();
+        RefreshSignatures();
         SaveCommand.NotifyCanExecuteChanged();
         SaveAsCommand.NotifyCanExecuteChanged();
         CloseCommand.NotifyCanExecuteChanged();

--- a/src/PromptResponse.Desktop/ViewModels/SignatureStatusItem.cs
+++ b/src/PromptResponse.Desktop/ViewModels/SignatureStatusItem.cs
@@ -1,0 +1,25 @@
+namespace PromptResponse.Desktop.ViewModels;
+
+/// <summary>
+/// Display record for one signature's verification + trust status in the
+/// signatures panel.
+/// </summary>
+/// <param name="Id">The signature id.</param>
+/// <param name="Role">"Publisher" or "Filler".</param>
+/// <param name="Signer">The signer's name (certificate subject).</param>
+/// <param name="Scope">What the signature covers ("form definition" or a field list).</param>
+/// <param name="ContentValid">Whether the covered content verifies (unaltered).</param>
+/// <param name="Trust">Trust level ("Trusted", "SelfSigned", "Untrusted", "Invalid").</param>
+/// <param name="Status">A human-readable status line.</param>
+public sealed record SignatureStatusItem(
+    string Id, string Role, string Signer, string Scope, bool ContentValid, string Trust, string Status)
+{
+    /// <summary>A short badge for the row: ✓ when content-valid, ✗ otherwise.</summary>
+    public string Badge => ContentValid ? "✓" : "✗";
+
+    /// <summary>Whether the signer's certificate is trusted (vs self-signed / untrusted).</summary>
+    public bool IsTrusted => string.Equals(Trust, "Trusted", System.StringComparison.Ordinal);
+
+    /// <summary>A compact header line for the row, e.g. "✓ Publisher — Town of Bloomfield".</summary>
+    public string Headline => $"{Badge} {Role} — {Signer}";
+}

--- a/src/PromptResponse.Desktop/Views/MainShellView.axaml
+++ b/src/PromptResponse.Desktop/Views/MainShellView.axaml
@@ -701,6 +701,47 @@
                                        TextWrapping="Wrap"/>
                         </StackPanel>
 
+                        <!-- Signatures — verification + trust status (shown when signed) -->
+                        <StackPanel Spacing="8" IsVisible="{Binding HasSignatures}"
+                                    AutomationProperties.Name="Signatures panel">
+                            <TextBlock Text="Signatures"
+                                       FontWeight="SemiBold"
+                                       FontSize="{Binding CaptionFontSize}"
+                                       Foreground="{Binding ActiveProfileMutedTextBrush}"/>
+                            <Button Content="Re-verify"
+                                    Command="{Binding RefreshSignaturesNowCommand}"
+                                    HorizontalAlignment="Stretch"
+                                    MinHeight="32"
+                                    CornerRadius="6"
+                                    AutomationProperties.Name="Re-verify signatures"
+                                    AutomationProperties.HelpText="Re-check each signature against the current content"/>
+                            <TextBlock Text="{Binding SignatureSummary}"
+                                       FontSize="{Binding BodyFontSize}"
+                                       AutomationProperties.LiveSetting="Polite"/>
+                            <ItemsControl ItemsSource="{Binding Signatures}"
+                                          x:Name="SignatureList"
+                                          AutomationProperties.Name="Signature list">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate DataType="vm:SignatureStatusItem">
+                                        <Border Padding="8,6" Margin="0,2"
+                                                CornerRadius="4" BorderThickness="1"
+                                                BorderBrush="{Binding #Root.((vm:MainShellViewModel)DataContext).ActiveProfileBorderBrush}"
+                                                AutomationProperties.Name="{Binding Headline}"
+                                                AutomationProperties.HelpText="{Binding Status}">
+                                            <StackPanel Spacing="2">
+                                                <TextBlock Text="{Binding Headline}"
+                                                           FontSize="12" FontWeight="SemiBold"/>
+                                                <TextBlock Text="{Binding Scope}"
+                                                           FontSize="11" Opacity="0.8" TextWrapping="Wrap"/>
+                                                <TextBlock Text="{Binding Status}"
+                                                           FontSize="11" Opacity="0.8" TextWrapping="Wrap"/>
+                                            </StackPanel>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+
                     </StackPanel>
                 </ScrollViewer>
             </Border>

--- a/tests/PromptResponse.Desktop.Tests/ViewModels/MainShellViewModelTests.cs
+++ b/tests/PromptResponse.Desktop.Tests/ViewModels/MainShellViewModelTests.cs
@@ -343,6 +343,57 @@ public class MainShellViewModelTests
         }
     }
 
+    [Fact]
+    public void LoadingSignedDocument_PopulatesSignaturesPanel()
+    {
+        var doc = MakeTemplate();
+        using var cert = PromptResponse.Core.Signing.SignatureCertificates.CreateSelfSigned(
+            "Town of Bloomfield", DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(1));
+        doc.Signatures = [PromptResponse.Core.Signing.AprSigner.SignTemplate(doc, cert, "https://gov/submit", DateTime.UtcNow)];
+
+        var session = new DocumentSessionService();
+        var shell = CreateShell(session: session);
+        session.Set(doc, null);
+
+        shell.HasSignatures.Should().BeTrue();
+        shell.Signatures.Should().ContainSingle();
+        shell.Signatures[0].Role.Should().Be("Publisher");
+        shell.Signatures[0].Signer.Should().Be("Town of Bloomfield");
+        shell.SignatureSummary.Should().Contain("all verify");
+    }
+
+    [Fact]
+    public void LoadingUnsignedDocument_HasNoSignatures()
+    {
+        var session = new DocumentSessionService();
+        var shell = CreateShell(session: session);
+        session.Set(MakeTemplate(), null);
+
+        shell.HasSignatures.Should().BeFalse();
+        shell.SignatureSummary.Should().Be("Not signed");
+    }
+
+    [Fact]
+    public void RefreshSignatures_AfterTamperingASignedField_ReportsInvalid()
+    {
+        var doc = MakeTemplate();
+        doc.Sections[0].Prompts[0].Response = "Ada";
+        using var cert = PromptResponse.Core.Signing.SignatureCertificates.CreateSelfSigned(
+            "Ada", DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(1));
+        doc.Signatures = [PromptResponse.Core.Signing.AprSigner.SignFields(doc, cert, ["p1"], DateTime.UtcNow, "f1")];
+
+        var session = new DocumentSessionService();
+        var shell = CreateShell(session: session);
+        session.Set(doc, null);
+        shell.Signatures[0].ContentValid.Should().BeTrue();
+
+        doc.Sections[0].Prompts[0].Response = "Mallory";
+        shell.RefreshSignatures();
+
+        shell.Signatures[0].ContentValid.Should().BeFalse();
+        shell.SignatureSummary.Should().Contain("INVALID");
+    }
+
     private static AprDocument ExprDoc() => new()
     {
         Metadata = new Metadata { Title = "T" },


### PR DESCRIPTION
Opening a signed form now shows a **Signatures** panel in the right rail (below Advisories): a summary ("N signature(s) — all verify" / "… one or more INVALID") and a row per signature with **role, signer, scope, and trust status**, plus a **Re-verify** button. Verified visually via headless render — e.g. *✓ Publisher — Town of Bloomfield*, *✓ Filler — Ada Lovelace*.

- Mirrors the advisories pattern: `RefreshSignatures()` runs on document load via `AprVerifier` (default trust — self-signed certs show as such until GUI pinning/CA trust is wired; not re-run per keystroke).
- New `SignatureStatusItem`; XAML panel with `AutomationProperties` throughout.
- 3 VM tests (signed → populated; unsigned → "Not signed"; tamper → INVALID); Desktop 680 → 683; a11y green.

In-GUI **signing** actions (cert picker + URL/password dialogs) are the remaining follow-up. (#73)

🤖 Generated with [Claude Code](https://claude.com/claude-code)