### PR TITLE
feat: in-GUI signing actions (File → Sign)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Desktop signing actions** (Path A) — File → **Sign** → *Sign as publisher…*
+  (pick a `.pfx`, enter the submission URL → signs the form definition and binds
+  the URL) and *Sign my responses…* (signs the fields you've answered). Adds a
+  text-input dialog (with password masking) and a certificate file picker; the
+  document is marked dirty and the Signatures panel refreshes. Completes the
+  in-GUI signing flow alongside the verify/trust panel. (#73)
+
 - **Desktop signatures panel** (Path A) — opening a signed form now shows a
   **Signatures** panel in the right rail: a one-line summary ("N signature(s) —
   all verify" / "… one or more INVALID") and a row per signature with role,

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -45,6 +45,17 @@ apr verify permit.aprf --trust=publisher.cer
 the certificate is trusted (`trusted` / `self-signed` / `untrusted` / `INVALID`),
 and exits non-zero if any signed content was altered.
 
+## Desktop
+
+With a form open, **File → Sign**:
+- **Sign as publisher…** — pick your `.pfx`, enter the submission URL; signs the
+  form definition and binds the URL.
+- **Sign my responses…** — signs the fields you've filled in.
+
+The right-rail **Signatures** panel shows each signature's role, signer, scope,
+and trust status (with a **Re-verify** button). (In-GUI trust pinning / CA
+configuration is a follow-up; self-signed certs show as such.)
+
 ## Commands
 
 ### `keygen`

--- a/src/PromptResponse.Desktop/Services/DialogService.cs
+++ b/src/PromptResponse.Desktop/Services/DialogService.cs
@@ -111,6 +111,72 @@ public class DialogService : IDialogService
         return result;
     }
 
+    /// <inheritdoc/>
+    public async Task<string?> ShowInputAsync(string title, string message, string defaultValue = "", bool isPassword = false)
+    {
+        _logger.LogDebug("Showing input dialog: {Title}", title);
+
+        var window = GetMainWindow();
+        if (window == null) return null;
+
+        string? result = null;
+
+        var dialog = new Window
+        {
+            Title = title,
+            Width = 460,
+            Height = 210,
+            MinWidth = 360,
+            MinHeight = 170,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            CanResize = false,
+            ShowInTaskbar = false,
+        };
+        dialog.SetValue(AutomationProperties.NameProperty, $"Input dialog: {title}");
+        dialog.SetValue(AutomationProperties.HelpTextProperty, message);
+
+        var label = new TextBlock
+        {
+            Text = message,
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Thickness(0, 0, 0, 8),
+        };
+
+        var input = new TextBox
+        {
+            Text = defaultValue,
+            PasswordChar = isPassword ? '•' : '\0',
+            MinWidth = 300,
+        };
+        input.SetValue(AutomationProperties.NameProperty, title);
+        input.SetValue(AutomationProperties.HelpTextProperty, message);
+
+        var okButton = new Button { Content = "OK", MinWidth = 80, Margin = new Thickness(0, 0, 10, 0), IsDefault = true };
+        okButton.SetValue(AutomationProperties.NameProperty, "Confirm input");
+        okButton.Click += (_, _) => { result = input.Text ?? string.Empty; dialog.Close(); };
+
+        var cancelButton = new Button { Content = "Cancel", MinWidth = 80, IsCancel = true };
+        cancelButton.SetValue(AutomationProperties.NameProperty, "Cancel input");
+        cancelButton.Click += (_, _) => { result = null; dialog.Close(); };
+
+        var buttons = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Margin = new Thickness(0, 12, 0, 0),
+            Children = { okButton, cancelButton },
+        };
+
+        dialog.Content = new StackPanel
+        {
+            Margin = new Thickness(20),
+            Children = { label, input, buttons },
+        };
+
+        await dialog.ShowDialog(window);
+        return result;
+    }
+
     private static Window? GetMainWindow()
     {
         return Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop

--- a/src/PromptResponse.Desktop/Services/FileService.cs
+++ b/src/PromptResponse.Desktop/Services/FileService.cs
@@ -173,6 +173,25 @@ public class FileService : IFileService
         return files.Count == 0 ? null : files[0].Path.LocalPath;
     }
 
+    public async Task<string?> PickCertificateAsync()
+    {
+        var window = GetMainWindow();
+        if (window == null) return null;
+
+        var files = await window.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Select signing certificate",
+            AllowMultiple = false,
+            FileTypeFilter = new[]
+            {
+                new FilePickerFileType("PKCS#12 certificate") { Patterns = new[] { "*.pfx", "*.p12" } },
+                new FilePickerFileType("All Files") { Patterns = new[] { "*" } }
+            }
+        });
+
+        return files.Count == 0 ? null : files[0].Path.LocalPath;
+    }
+
     public async Task<string?> PickExportPathAsync(string suggestedFileName, string title, string typeLabel, string extension)
     {
         var window = GetMainWindow();

--- a/src/PromptResponse.Desktop/Services/IDialogService.cs
+++ b/src/PromptResponse.Desktop/Services/IDialogService.cs
@@ -12,4 +12,15 @@ public interface IDialogService
     /// <param name="message">The confirmation message to display.</param>
     /// <returns>True if the user clicked Yes, false otherwise.</returns>
     Task<bool> ShowConfirmationAsync(string title, string message);
+
+    /// <summary>
+    /// Shows a single-line text input dialog and returns the entered text, or
+    /// <c>null</c> if the user cancelled. An empty string means the user accepted
+    /// with no text (distinct from cancelling).
+    /// </summary>
+    /// <param name="title">The dialog title.</param>
+    /// <param name="message">The prompt shown above the input.</param>
+    /// <param name="defaultValue">The initial text in the input.</param>
+    /// <param name="isPassword">Whether to mask the input (for passwords).</param>
+    Task<string?> ShowInputAsync(string title, string message, string defaultValue = "", bool isPassword = false);
 }

--- a/src/PromptResponse.Desktop/Services/IFileService.cs
+++ b/src/PromptResponse.Desktop/Services/IFileService.cs
@@ -60,6 +60,12 @@ public interface IFileService
     Task<string?> PickPdfImportPathAsync();
 
     /// <summary>
+    /// Shows an open-file dialog filtered to PKCS#12 certificates (.pfx/.p12) and
+    /// returns the chosen path, or null if cancelled.
+    /// </summary>
+    Task<string?> PickCertificateAsync();
+
+    /// <summary>
     /// Gets the last opened or saved file path.
     /// </summary>
     string? CurrentFilePath { get; }

--- a/src/PromptResponse.Desktop/ViewModels/MainShellViewModel.cs
+++ b/src/PromptResponse.Desktop/ViewModels/MainShellViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Media;
 using Avalonia.Styling;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using System.Security.Cryptography.X509Certificates;
 using PromptResponse.Core.Expressions;
 using PromptResponse.Core.Models;
 using PromptResponse.Core.Signing;
@@ -467,6 +468,93 @@ public sealed partial class MainShellViewModel : ObservableObject, IDisposable
     /// <summary>Re-verifies signatures on demand (e.g. after editing responses).</summary>
     [RelayCommand]
     public void RefreshSignaturesNow() => RefreshSignatures();
+
+    /// <summary>
+    /// Signs the open document as the publisher with a chosen X.509 certificate
+    /// (.pfx), binding a submission URL. Adds the signature and marks the document
+    /// dirty so the user saves it.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(HasDocument))]
+    public async Task SignAsPublisher()
+    {
+        var doc = _session.CurrentDocument;
+        if (doc is null) return;
+
+        var certPath = await _fileService.PickCertificateAsync();
+        if (string.IsNullOrEmpty(certPath)) return;
+
+        var password = await _dialogService.ShowInputAsync(
+            "Certificate password", "Enter the certificate password (leave blank if none):", string.Empty, isPassword: true);
+        if (password is null) return; // cancelled
+
+        var url = await _dialogService.ShowInputAsync(
+            "Submission URL", "Where is this form submitted? (bound into the signature)", doc.Metadata.SubmissionUrl ?? string.Empty);
+        if (url is null) return; // cancelled
+
+        await SignWith(certPath!, password, c =>
+        {
+            var sig = AprSigner.SignTemplate(doc, c, string.IsNullOrEmpty(url) ? null : url, DateTime.UtcNow);
+            doc.Metadata.Publisher ??= sig.Signer.Name;
+            if (!string.IsNullOrEmpty(url)) doc.Metadata.SubmissionUrl = url;
+            return sig;
+        });
+    }
+
+    /// <summary>
+    /// Signs the responses the user has filled in (all answered fields) with a
+    /// chosen X.509 certificate.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(HasDocument))]
+    public async Task SignMyResponses()
+    {
+        var doc = _session.CurrentDocument;
+        if (doc is null) return;
+
+        var answered = FormExpressions.GetAllPrompts(doc)
+            .Where(p => !string.IsNullOrEmpty(p.Id) && !string.IsNullOrWhiteSpace(p.Response))
+            .Select(p => p.Id)
+            .ToList();
+        if (answered.Count == 0)
+        {
+            await _dialogService.ShowConfirmationAsync(
+                "Nothing to sign", "Fill in some responses first — a filler signature covers the fields you've answered.");
+            return;
+        }
+
+        var certPath = await _fileService.PickCertificateAsync();
+        if (string.IsNullOrEmpty(certPath)) return;
+
+        var password = await _dialogService.ShowInputAsync(
+            "Certificate password", "Enter the certificate password (leave blank if none):", string.Empty, isPassword: true);
+        if (password is null) return;
+
+        var id = $"sig{(doc.Signatures?.Count ?? 0) + 1}";
+        await SignWith(certPath!, password, c => AprSigner.SignFields(doc, c, answered, DateTime.UtcNow, id));
+    }
+
+    private async Task SignWith(string certPath, string password, Func<X509Certificate2, Signature> sign)
+    {
+        var doc = _session.CurrentDocument;
+        if (doc is null) return;
+        try
+        {
+            using var cert = SignatureCertificates.LoadPfx(certPath, string.IsNullOrEmpty(password) ? null : password);
+            if (!cert.HasPrivateKey)
+            {
+                await _dialogService.ShowConfirmationAsync("Cannot sign", "That certificate has no private key — choose a .pfx that includes the key.");
+                return;
+            }
+            var signature = sign(cert);
+            doc.Signatures ??= new List<Signature>();
+            doc.Signatures.Add(signature);
+            _session.MarkDirty();
+            RefreshSignatures();
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowConfirmationAsync("Signing failed", ex.Message);
+        }
+    }
 
     /// <summary>
     /// Re-runs the advisory inspection over the current document. Per the vision,
@@ -985,6 +1073,8 @@ public sealed partial class MainShellViewModel : ObservableObject, IDisposable
         ToggleEditModeCommand.NotifyCanExecuteChanged();
         RefreshAdvisories();
         RefreshSignatures();
+        SignAsPublisherCommand.NotifyCanExecuteChanged();
+        SignMyResponsesCommand.NotifyCanExecuteChanged();
         SaveCommand.NotifyCanExecuteChanged();
         SaveAsCommand.NotifyCanExecuteChanged();
         CloseCommand.NotifyCanExecuteChanged();

--- a/src/PromptResponse.Desktop/Views/MainShellView.axaml
+++ b/src/PromptResponse.Desktop/Views/MainShellView.axaml
@@ -79,6 +79,17 @@
                               AutomationProperties.Name="Export as fillable web form"
                               AutomationProperties.HelpText="Export a self-contained HTML form that fills in the browser and downloads an .aprf file"/>
                 </MenuItem>
+                <MenuItem Header="Si_gn"
+                          AutomationProperties.Name="Sign menu">
+                    <MenuItem Header="Sign as _publisher..."
+                              Command="{Binding SignAsPublisherCommand}"
+                              AutomationProperties.Name="Sign as publisher"
+                              AutomationProperties.HelpText="Sign the form definition with a certificate and bind a submission URL"/>
+                    <MenuItem Header="Sign my _responses..."
+                              Command="{Binding SignMyResponsesCommand}"
+                              AutomationProperties.Name="Sign my responses"
+                              AutomationProperties.HelpText="Sign the fields you have filled in with a certificate"/>
+                </MenuItem>
                 <Separator/>
                 <MenuItem Header="_Close"
                           Command="{Binding CloseCommand}"

--- a/tests/PromptResponse.Desktop.Tests/ViewModels/MainShellViewModelTests.cs
+++ b/tests/PromptResponse.Desktop.Tests/ViewModels/MainShellViewModelTests.cs
@@ -394,6 +394,98 @@ public class MainShellViewModelTests
         shell.SignatureSummary.Should().Contain("INVALID");
     }
 
+    private static string MakeTempPfx(string cn = "Town of Bloomfield")
+    {
+        using var cert = PromptResponse.Core.Signing.SignatureCertificates.CreateSelfSigned(
+            cn, DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(1));
+        var path = Path.Combine(Path.GetTempPath(), $"cert_{Guid.NewGuid():N}.pfx");
+        File.WriteAllBytes(path, cert.Export(System.Security.Cryptography.X509Certificates.X509ContentType.Pkcs12));
+        return path;
+    }
+
+    [Fact]
+    public async Task SignAsPublisher_AddsPublisherSignature_BindsUrl_AndMarksDirty()
+    {
+        var pfx = MakeTempPfx();
+        var fs = Substitute.For<IFileService>();
+        var dlg = Substitute.For<IDialogService>();
+        fs.PickCertificateAsync().Returns(pfx);
+        dlg.ShowInputAsync("Certificate password", Arg.Any<string>(), Arg.Any<string>(), true).Returns("");
+        dlg.ShowInputAsync("Submission URL", Arg.Any<string>(), Arg.Any<string>(), false).Returns("https://gov/submit");
+
+        var session = new DocumentSessionService();
+        var shell = CreateShell(fs, dialogService: dlg, session: session);
+        session.Set(MakeTemplate(), null);
+
+        try
+        {
+            await shell.SignAsPublisher();
+
+            var doc = session.CurrentDocument!;
+            doc.Signatures.Should().ContainSingle().Which.Role.Should().Be(SignatureRole.Publisher);
+            doc.Metadata.SubmissionUrl.Should().Be("https://gov/submit");
+            session.IsDirty.Should().BeTrue();
+            shell.HasSignatures.Should().BeTrue();
+        }
+        finally { File.Delete(pfx); }
+    }
+
+    [Fact]
+    public async Task SignMyResponses_SignsAnsweredFields()
+    {
+        var pfx = MakeTempPfx("Ada");
+        var fs = Substitute.For<IFileService>();
+        var dlg = Substitute.For<IDialogService>();
+        fs.PickCertificateAsync().Returns(pfx);
+        dlg.ShowInputAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), true).Returns("");
+
+        var session = new DocumentSessionService();
+        var shell = CreateShell(fs, dialogService: dlg, session: session);
+        var doc = MakeTemplate();
+        doc.Sections[0].Prompts[0].Response = "Ada Lovelace"; // p1 answered; p2 blank
+        session.Set(doc, null);
+
+        try
+        {
+            await shell.SignMyResponses();
+
+            var sig = session.CurrentDocument!.Signatures.Should().ContainSingle().Subject;
+            sig.Role.Should().Be(SignatureRole.Filler);
+            sig.Fields.Should().Contain("p1").And.NotContain("p2");
+        }
+        finally { File.Delete(pfx); }
+    }
+
+    [Fact]
+    public async Task SignAsPublisher_WhenCertPickerCancelled_AddsNothing()
+    {
+        var fs = Substitute.For<IFileService>();
+        fs.PickCertificateAsync().Returns((string?)null);
+        var session = new DocumentSessionService();
+        var shell = CreateShell(fs, session: session);
+        session.Set(MakeTemplate(), null);
+
+        await shell.SignAsPublisher();
+
+        (session.CurrentDocument!.Signatures ?? new()).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SignMyResponses_WithNoAnsweredFields_ShowsDialog_AndSignsNothing()
+    {
+        var fs = Substitute.For<IFileService>();
+        var dlg = Substitute.For<IDialogService>();
+        var session = new DocumentSessionService();
+        var shell = CreateShell(fs, dialogService: dlg, session: session);
+        session.Set(MakeTemplate(), null); // no responses
+
+        await shell.SignMyResponses();
+
+        await dlg.Received(1).ShowConfirmationAsync(Arg.Any<string>(), Arg.Any<string>());
+        await fs.DidNotReceive().PickCertificateAsync();
+        (session.CurrentDocument!.Signatures ?? new()).Should().BeEmpty();
+    }
+
     private static AprDocument ExprDoc() => new()
     {
         Metadata = new Metadata { Title = "T" },


### PR DESCRIPTION
Completes the desktop signing flow — you can now **create** signatures in the app, not just verify them.

**File → Sign:**
- **Sign as publisher…** — pick a `.pfx`, enter the submission URL → signs the form definition, **binds the URL**, records `metadata.publisher`/`submissionUrl`.
- **Sign my responses…** — signs the fields you've answered (filler).

Infrastructure added: `IDialogService.ShowInputAsync` (text-input dialog with password masking) + `IFileService.PickCertificateAsync` (.pfx picker). A `SignWith` helper loads the cert, signs, marks dirty, and refreshes the Signatures panel; errors / 'no private key' surface via a dialog.

4 VM tests (publisher binds URL + dirty, filler signs answered fields, cancel = no-op, nothing-to-sign dialog); Desktop 683 → 687; a11y green; menu items carry AutomationProperties.

This closes the in-GUI signing surface — the full sign + verify + trust flow now works from the desktop app. (#73)

🤖 Generated with [Claude Code](https://claude.com/claude-code)