### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-09
+
+The **Path A (local-first / sovereignty / accessibility) wedge**, delivered:
+verifiable **digital signatures** (CMS/PKCS#7 + X.509 — publisher signs the
+template & binds the submission URL, fillers sign their scoped responses; CLI +
+desktop + status in exports), **PDF/A-2b archival** export (veraPDF-validated),
+**richer print** (running footer, page size, classification/handling banners),
+and **deeper import** (AcroForm importer with a self-scoring quality report + the
+portable `document-to-apr` skill + the importer→skill hybrid). Bundles the
+vendored pdfe bump to 2.9.0.
+
 ### Added
 
 - **PDF/A archival export** (Path A) — `apr export <file> --format=pdf --pdfa`

--- a/src/PromptResponse.Cli/PromptResponse.Cli.csproj
+++ b/src/PromptResponse.Cli/PromptResponse.Cli.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <PackageId>PromptResponse.Cli</PackageId>
-    <Version>0.5.0</Version>
+    <Version>0.6.0</Version>
     <Authors>PromptResponse Contributors</Authors>
     <Description>Command-line tool for working with APR (Adaptive Prompt Response) files</Description>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>

--- a/src/PromptResponse.Core/PromptResponse.Core.csproj
+++ b/src/PromptResponse.Core/PromptResponse.Core.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <PackageId>PromptResponse.Core</PackageId>
-    <Version>0.5.0</Version>
+    <Version>0.6.0</Version>
     <Authors>PromptResponse Contributors</Authors>
     <Description>Core library for APR (Adaptive Prompt Response) form format</Description>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>

--- a/src/PromptResponse.Desktop/PromptResponse.Desktop.csproj
+++ b/src/PromptResponse.Desktop/PromptResponse.Desktop.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>0.5.0</Version>
+    <Version>0.6.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Cuts **v0.6.0** — the Path A wedge.

**Highlights** (full list in CHANGELOG):
- **Verifiable signatures** — CMS/PKCS#7 + X.509; publisher signs the template + binds the submit URL, fillers sign scoped responses; CLI (`keygen`/`sign`/`verify`) + desktop sign/verify panel + status in PDF/HTML exports.
- **PDF/A-2b archival** export (`--pdfa`) — veraPDF-validated 144/144.
- **Richer print** — running footer, page size (Letter/A4/Legal), classification banners.
- **Deeper import** — AcroForm importer with a self-scoring quality report + the portable `document-to-apr` skill + the importer→skill hybrid.
- Vendored **pdfe 2.9.0**.

App 0.5.0 → 0.6.0. Tagging `v0.6.0` after merge triggers the release build (installers + the document-to-apr skill zip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)